### PR TITLE
Resolve comment parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ from pyterraformer import HumanSerializer
 
 hs = HumanSerializer(terraform='/path/to/my/terraform/binary')
 
-example_string = '''resource "aws_s3_bucket" "b" {
+example_string:str = '''resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
-
+  
   tags = {
-    Name        = "My bucket"
+Name        = "My bucket"
     Environment = "Dev"
   }
 }'''
@@ -61,7 +61,7 @@ example_string = '''resource "aws_s3_bucket" "b" {
 namespace = hs.parse_string(example_string)
 
 # get the bucket from that list
-bucket = namespace.objects[0]
+bucket = namespace[0]
 
 # modify the bucket
 bucket.tags["Environment"] = "Prod"
@@ -73,13 +73,11 @@ updated = hs.render_object(bucket, format=True)
 
 assert updated == '''resource "aws_s3_bucket" "b" {
   bucket = "my-updated-bucket"
-
   tags = {
     Name        = "My bucket"
     Environment = "Prod"
   }
-}
-'''
+}'''
 
 ```
 

--- a/pyterraformer/__init__.py
+++ b/pyterraformer/__init__.py
@@ -4,7 +4,7 @@ from .serializer import HumanSerializer
 from .terraform.backends import LocalBackend
 from .terraform.terraform import Terraform
 
-__version__ = "0.0.1-rc.2"
+__version__ = "0.0.1-rc.3"
 
 __all__ = [
     "HumanSerializer",

--- a/pyterraformer/__init__.py
+++ b/pyterraformer/__init__.py
@@ -4,7 +4,7 @@ from .serializer import HumanSerializer
 from .terraform.backends import LocalBackend
 from .terraform.terraform import Terraform
 
-__version__ = "0.0.1-rc.1"
+__version__ = "0.0.1-rc.2"
 
 __all__ = [
     "HumanSerializer",

--- a/pyterraformer/core/generics/local.py
+++ b/pyterraformer/core/generics/local.py
@@ -8,7 +8,7 @@ class Local(TerraformObject):
             pass_on.append([key, value])
 
         TerraformObject.__init__(
-            self, type="local", original_text=text, attributes=pass_on
+            self, _type="local", original_text=text, attributes=pass_on
         )
 
     # def render(self, variables=None):

--- a/pyterraformer/core/generics/meta_arguments.py
+++ b/pyterraformer/core/generics/meta_arguments.py
@@ -7,7 +7,7 @@ from pyterraformer.core.objects import TerraformObject, ObjectMetadata
 class Provider(TerraformObject):
     def __init__(self, type: str, _metadata: Optional[ObjectMetadata] = None, **kwargs):
         self.ptype = str(type).replace('"', "")
-        TerraformObject.__init__(self, type="provider", _metadata=_metadata)
+        TerraformObject.__init__(self, _type="provider", _metadata=_metadata)
 
     def __repr__(self):
         return (

--- a/pyterraformer/serializer/human_resources/engine.py
+++ b/pyterraformer/serializer/human_resources/engine.py
@@ -36,7 +36,8 @@ from pyterraformer.core.generics import (
     ToSet,
 )
 from pyterraformer.core.modules import ModuleObject
-from pyterraformer.core.objects import ObjectMetadata
+from pyterraformer.core.objects import ObjectMetadata, TerraformObject
+from typing import List
 
 # TODO: rewrite to comply with https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md
 
@@ -446,15 +447,7 @@ class ParseToObjects(Transformer):
 TERRAFORM_PARSER = Lark(grammar, start="start", propagate_positions=True)
 
 
-def parse_text(text: str):
-    # if print_flag:
-    #     parsed = TERRAFORM_PARSER.parse(text)
-    #     for row in parsed.children:
-    #         if isinstance(row, Tree):
-    #             for item in row.children:
-    #                 print(item)
-    #         else:
-    #             print(row)
+def parse_text(text: str) -> List[TerraformObject]:
     return ParseToObjects(visit_tokens=True, text=text).transform(
         TERRAFORM_PARSER.parse(text)
     )

--- a/pyterraformer/serializer/human_resources/engine.py
+++ b/pyterraformer/serializer/human_resources/engine.py
@@ -212,9 +212,9 @@ grammar = r"""
 """
 
 
-def args_to_dict(input: list) -> dict[str, Any]:
-    output: dict = {}
-    for array in input:
+def args_to_dict(input_list: list) -> Dict[str, Any]:
+    output: Dict[str, Any] = {}
+    for array in input_list:
         key = array[0]
         val = array[1]
         # a comment might show up as a third object on a line

--- a/pyterraformer/serializer/human_resources/engine.py
+++ b/pyterraformer/serializer/human_resources/engine.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Any
 
 from lark import Lark, Transformer, v_args
 from lark.tree import Meta
@@ -44,7 +44,7 @@ from typing import List
 RESOURCES_MAP: Dict = {}
 
 grammar = r"""
-    start: (comment| item | symlink)*
+    start: ( item | symlink)*
     ?item: resource
     | object
     | module
@@ -55,24 +55,27 @@ grammar = r"""
     | data
     | output
     | multiline_comment
+    | comment
 
     //TODO: in parsing - follow symlinks?
     symlink: "."+ "/" /[a-zA-Z_\-]+/ ".tf"
 
-    resource: "resource" string_lit string_lit  "{" (comment| sub_object | lifecycle | provider | split_subarray ) + "}"
+    resource: "resource" string_lit string_lit  "{" (nested_comment| sub_object | lifecycle | provider | split_subarray ) + "}"
+    
+    nested_comment: comment
+    
+    output: "output" string_lit "{"[( nested_comment| sub_object)+] "}"
 
-    output: "output" string_lit "{"[( comment| sub_object)+] "}"
-
-    module: "module" string_lit  "{"  (comment | sub_object | split_subarray)+ "}"
+    module: "module" string_lit  "{"  (nested_comment | sub_object | split_subarray)+ "}"
 
     lifecycle: "lifecycle"  "{" [sub_object ( sub_object)*] "}"
 
     // this exists without the = option as a perf optimization
-    split_subarray: IDENTIFIER "{" [(comment|sub_object|split_subarray)+] "}"
+    split_subarray: IDENTIFIER "{" [(nested_comment|sub_object|split_subarray)+] "}"
 
     provider: "provider" (string_lit | IDENTIFIER)  "{" [(sub_object | split_subarray) ( sub_object| split_subarray)*]  "}"
 
-    data: "data" string_lit string_lit "{" [(sub_object | split_subarray | comment) ( sub_object| split_subarray | comment)*] "}"
+    data: "data" string_lit string_lit "{" [(sub_object | split_subarray | nested_comment) ( sub_object| split_subarray | nested_comment)*] "}"
 
     metadata: "metadata" "{" [sub_object ( sub_object)*] "}"
 
@@ -80,7 +83,7 @@ grammar = r"""
 
     locals: "locals" dict
 
-    variable: "variable" (string_lit | IDENTIFIER) "{" (comment | variable_type_declaration| variable_default_declaration | variable_description)* "}"
+    variable: "variable" (string_lit | IDENTIFIER) "{" (nested_comment | variable_type_declaration| variable_default_declaration | variable_description)* "}"
 
     variable_type_declaration: ("type" | "\"type\"") "=" (types | ( "\""  TYPE"\"" ))
     variable_description: ("description" | "\"description\"") "=" (string_lit | heredoc_eof)
@@ -93,16 +96,16 @@ grammar = r"""
 
     // handling inside items
     // figure out how to handle comments better
-    tuple: "["  [ comment* (string_lit| int_lit| dict| tuple | lookup | EMPTY_STRING )  ( "," comment*  (string_lit| int_lit| dict| tuple | lookup) )*] ","? comment?  "]" -> tuple
+    tuple: "["  [ nested_comment* (string_lit| int_lit| dict| tuple | lookup | EMPTY_STRING )  ( "," nested_comment*  (string_lit| int_lit| dict| tuple | lookup) )*] ","? nested_comment?  "]" -> tuple
 
     // replace with expr_contents
     // figure out why dot identifiers are ever valid
-    sub_object: (IDENTIFIER |string_lit | IDENTIFIER_WITH_DOT) "=" ( setsubtract | lookup | tuple | string_lit | file | toset | concat | merge | boolean | dict | int_lit | object_access |  conditional | heredoc_eof | IDENTIFIER | generic_function | list_comp) ","? comment?   -> sub_object
+    sub_object: (IDENTIFIER |string_lit | IDENTIFIER_WITH_DOT) "=" ( setsubtract | lookup | tuple | string_lit | file | toset | concat | merge | boolean | dict | int_lit | object_access |  conditional | heredoc_eof | IDENTIFIER | generic_function | list_comp) ","? nested_comment?    -> sub_object
 
     // annoyingly repetitive
-    dict_sub_object: (IDENTIFIER |string_lit | IDENTIFIER_WITH_DOT) ("=" | ":") ( setsubtract | lookup | tuple | string_lit | file | toset | concat | merge | boolean | dict | int_lit | object_access |  conditional | heredoc_eof | IDENTIFIER | generic_function | list_comp) ","? comment?   -> sub_object
+    dict_sub_object: (IDENTIFIER |string_lit | IDENTIFIER_WITH_DOT) ("=" | ":") ( setsubtract | lookup | tuple | string_lit | file | toset | concat | merge | boolean | dict | int_lit | object_access |  conditional | heredoc_eof | IDENTIFIER | generic_function | list_comp) ","? nested_comment?  -> sub_object
 
-    dict: "{" (comment | dict_sub_object )* "}"
+    dict: "{" (nested_comment | dict_sub_object )* "}"
 
     object_access: IDENTIFIER "." IDENTIFIER
 
@@ -164,7 +167,7 @@ grammar = r"""
                 | heredoc_template
                 | heredoc_template_trim
                 | list_comp
-                | comment
+                | nested_comment
                 | tuple
                 | null
 
@@ -209,10 +212,16 @@ grammar = r"""
 """
 
 
-def args_to_dict(input: list) -> dict:
-    output = {}
-    # {str(val): key for val, key in args}
-    for key, val in input:
+def args_to_dict(input: list) -> dict[str, Any]:
+    output: dict = {}
+    for array in input:
+        key = array[0]
+        val = array[1]
+        # a comment might show up as a third object on a line
+        # flatten that out
+        if len(array) > 2:
+            nested = array[2]
+            output = {**output, **args_to_dict([nested])}
         if key not in output:
             output[str(key)] = val
         else:
@@ -325,7 +334,12 @@ class ParseToObjects(Transformer):
     def comment(self, meta: Meta, args):
         metadata = self.generate_metadata(meta)
         out = Comment(text=args[0].value, _metadata=metadata)
-        return [f"comment-{metadata.start_pos}", out]
+        return out
+
+    @v_args(meta=True)
+    def nested_comment(self, meta: Meta, args):
+        """Special comment to maintain position within other objects"""
+        return [f"comment-{meta.start_pos}", args[0]]
 
     @v_args(meta=True)
     def multiline_comment(self, meta: Meta, args):

--- a/pyterraformer/serializer/human_serializer.py
+++ b/pyterraformer/serializer/human_serializer.py
@@ -14,6 +14,7 @@ from pyterraformer.core.modules import ModuleObject
 from pyterraformer.core.resources import ResourceObject
 from pyterraformer.serializer.base_serializer import BaseSerializer
 from pyterraformer.serializer.human_resources.engine import parse_text
+from pyterraformer.exceptions import TerraformExecutionError
 
 if TYPE_CHECKING:
     from pyterraformer.terraform import Terraform
@@ -111,6 +112,11 @@ class HumanSerializer(BaseSerializer):
             file_name.write_text(string)
             try:
                 self.terraform.run("fmt", path=td)
+            except FileNotFoundError as e:
+                logger.error(str(e))
+                raise TerraformExecutionError(
+                    f"File not found - is the terraform executable path set correctly and accessible to this user? Error: {str(e)}"
+                )
             except CalledProcessError as e:
                 logger.error(f"Unable to format file \n{string}")
                 raise e

--- a/scripts/create_provider_stubs.py
+++ b/scripts/create_provider_stubs.py
@@ -325,7 +325,7 @@ def save_stubs(provider: str, version: str, stubs: dict, path: str):
 
 @click.command()
 @click.option(
-    "--package", help="The package name, eg. hashicorp/aws to create stubs for"
+    "--provider", help="The provider name, eg. hashicorp/aws to create stubs for"
 )
 @click.option("--version", help="The version of the provider to create stubs for. ")
 @click.option("--terraform_path", help="The path of the local terraform binary.")

--- a/tests/test_parsing/cases/comments.tf
+++ b/tests/test_parsing/cases/comments.tf
@@ -1,0 +1,10 @@
+resource "aws_s3_bucket" "b" {
+  test = false
+  # maintain position
+  bucket = "my-tf-test-bucket"
+  # this is a helpful comment
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
+  }
+}

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,32 @@
+from pyterraformer.exceptions import TerraformExecutionError
+import pytest
+
+
+def test_readme():
+    from pyterraformer import HumanSerializer
+
+    hs = HumanSerializer(terraform="/path/to/my/terraform/binary/does/not/exist")
+
+    example_string: str = """resource "aws_s3_bucket" "b" {
+      bucket = "my-tf-test-bucket"
+      
+      tags = {
+    Name        = "My bucket"
+        Environment = "Dev"
+      }
+    }"""
+
+    # parse a string into a list of terraform objects
+    namespace = hs.parse_string(example_string)
+
+    # get the bucket from that list
+    bucket = namespace[0]
+
+    # modify the bucket
+    bucket.tags["Environment"] = "Prod"
+    bucket.bucket = "my-updated-bucket"
+
+    # and write the modified namespace back
+    # formatting requires a valid terraform binary to be provided
+    with pytest.raises(TerraformExecutionError):
+        updated = hs.render_object(bucket, format=True)


### PR DESCRIPTION
## Description

This standardizes the output of top level parsing to be Terraform Objects; comments were previously mistakenly an array.

Closes #14 

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/oss-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
