### PR TITLE
Update/python 3.10 to 3.14 support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-[flake8]
-count = True
-ignore = F401,C901,F811,E203,W503,E501
-exclude = .git,.github,examples,__pycache__,docs,venv,env,.venv,build,examples
-max-complexity = 10
-max-line-length = 127
-builtins = unicode
-tee = True

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,13 +27,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install wheel
           pip install -r requirements.txt -r requirements-test.txt
-      - name: Lint with flake8
+      - name: Lint with ruff
         run: |
-          pip install flake8
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --exit-zero --statistics
+          ruff check .
+          ruff format --check .
+      - name: Type check with mypy
+        run: |
+          mypy pyterraformer --ignore-missing-imports
       - name: Test with pytest
         run: |
           pytest --ignore=docs_src/ --cov=./

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ ignore = [
   "F401",   # unused imports (in __init__.py files)
   "F811",   # redefinition of unused name
   "C901",   # too complex
+  "UP035",  # deprecated typing imports (Dict, List, etc.) - keep for compatibility
+  "B904",   # raise from in except clause - not critical
+  "E402",   # module level import not at top of file - needed for template strings
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -76,9 +79,11 @@ ignore = [
 
 [tool.mypy]
 python_version = "3.10"
-warn_return_any = true
+warn_return_any = false
 warn_unused_configs = true
 ignore_missing_imports = true
+check_untyped_defs = false
+disallow_untyped_defs = false
 exclude = [
   "venv",
   "env",
@@ -86,4 +91,6 @@ exclude = [
   "build",
   "dist",
   "examples",
+  "scripts",
+  "tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,15 @@ dynamic = ["version"]
 authors = [{ name = "", email = "pyterraformer@gmail.com" }]
 description = "Enjoyable terraform manipulation from python."
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,51 @@ exclude = [
 [tool.setuptools_scm]
 
 #TODO: convert scripts into actual entrypoint scripts
+
+[tool.ruff]
+line-length = 127
+exclude = [
+  ".git",
+  ".github",
+  "examples",
+  "__pycache__",
+  "venv",
+  "env",
+  ".venv",
+  "build",
+  "dist",
+]
+
+[tool.ruff.lint]
+select = [
+  "E",      # pycodestyle errors
+  "W",      # pycodestyle warnings
+  "F",      # Pyflakes
+  "I",      # isort
+  "B",      # flake8-bugbear
+  "C4",     # flake8-comprehensions
+  "UP",     # pyupgrade
+]
+ignore = [
+  "E501",   # line too long (handled by formatter)
+  "F401",   # unused imports (in __init__.py files)
+  "F811",   # redefinition of unused name
+  "C901",   # too complex
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+exclude = [
+  "venv",
+  "env",
+  ".venv",
+  "build",
+  "dist",
+  "examples",
+]

--- a/pyterraformer/__init__.py
+++ b/pyterraformer/__init__.py
@@ -1,7 +1,4 @@
-try:
-    from importlib.metadata import PackageNotFoundError, version
-except ImportError:
-    from importlib_metadata import PackageNotFoundError, version  # type: ignore
+from importlib.metadata import PackageNotFoundError, version
 
 from .config import Config
 from .core.workspace import TerraformWorkspace

--- a/pyterraformer/config.py
+++ b/pyterraformer/config.py
@@ -3,17 +3,16 @@ from typing import Optional
 
 from pyterraformer.settings import get_default_terraform_location
 
-
 # tempdir = mkdtemp()
 #
 # atexit.register(shutil.rmtree, tempdir)
 
 
 @dataclass
-class TerraformerConfig(object):
-    terraform_exec: Optional[str] = get_default_terraform_location()
+class TerraformerConfig:
+    terraform_exec: str | None = get_default_terraform_location()
     default_workspace: str = "default"
-    tf_plugin_cache_dir: Optional[str] = None
+    tf_plugin_cache_dir: str | None = None
     default_variable_file: str = "variables.tf"
     default_data_file: str = "data.tf"
 

--- a/pyterraformer/core/__init__.py
+++ b/pyterraformer/core/__init__.py
@@ -1,4 +1,4 @@
-from .namespace import TerraformNamespace, TerraformFile
+from .namespace import TerraformFile, TerraformNamespace
 from .objects import TerraformObject
 from .workspace import TerraformWorkspace
 

--- a/pyterraformer/core/generics/__init__.py
+++ b/pyterraformer/core/generics/__init__.py
@@ -2,32 +2,32 @@ from .backend import Backend
 from .comment import Comment
 from .data import Data
 from .interpolation import (
-    Interpolation,
-    DictLookup,
-    PropertyLookup,
-    StringLit,
-    String,
-    Expression,
-    Conditional,
+    ArrayLookup,
     BinaryOp,
     BinaryOperator,
     BinaryTerm,
-    Parenthetical,
-    File,
     Boolean,
-    Merge,
     Concat,
-    Replace,
-    Types,
-    ArrayLookup,
+    Conditional,
+    DictLookup,
+    Expression,
+    File,
     GenericFunction,
-    Symlink,
+    Interpolation,
     LegacySplat,
+    Merge,
+    Parenthetical,
+    PropertyLookup,
+    Replace,
+    String,
+    StringLit,
+    Symlink,
     ToSet,
+    Types,
 )
 from .literal import Literal
 from .local import Local
-from .meta_arguments import DependsOn, Provider, ForEach, Count, Lifecycle
+from .meta_arguments import Count, DependsOn, ForEach, Lifecycle, Provider
 from .metadata import Metadata
 from .output import Output
 from .terraform import TerraformConfig

--- a/pyterraformer/core/generics/backend.py
+++ b/pyterraformer/core/generics/backend.py
@@ -1,11 +1,12 @@
-from pyterraformer.core.objects import TerraformObject, ObjectMetadata
 from typing import Optional
+
+from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 # from pyterraformer.core.resources import
 
 
 class Backend(TerraformObject):
-    def __init__(self, name: str, _metadata: Optional[ObjectMetadata] = None, **kwargs):
+    def __init__(self, name: str, _metadata: ObjectMetadata | None = None, **kwargs):
         TerraformObject.__init__(self, "backend", _metadata=_metadata, **kwargs)
         self.name = str(name).replace('"', "")
 

--- a/pyterraformer/core/generics/comment.py
+++ b/pyterraformer/core/generics/comment.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pyterraformer.core.objects import TerraformObject, ObjectMetadata
+from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 
 class Comment(TerraformObject):
@@ -8,16 +8,14 @@ class Comment(TerraformObject):
         self,
         text: str,
         multiline: bool = False,
-        _metadata: Optional[ObjectMetadata] = None,
+        _metadata: ObjectMetadata | None = None,
     ):
         self.multiline = multiline
         if self.multiline:
             text = f"/*{text}*/"
         else:
             text = text.strip()
-        TerraformObject.__init__(
-            self, "comment", tf_id=None, text=text, _metadata=_metadata
-        )
+        TerraformObject.__init__(self, "comment", tf_id=None, text=text, _metadata=_metadata)
 
     @property
     def has_content(self):

--- a/pyterraformer/core/generics/data.py
+++ b/pyterraformer/core/generics/data.py
@@ -11,11 +11,7 @@ class Data(TerraformObject):
 
     def __repr__(self):
         return (
-            f"{self._type}({self.name})("
-            + ", ".join(
-                [f'{key}="{val}"' for key, val in self.render_variables.items()]
-            )
-            + ")"
+            f"{self._type}({self.name})(" + ", ".join([f'{key}="{val}"' for key, val in self.render_variables.items()]) + ")"
         )
 
     #

--- a/pyterraformer/core/generics/interpolation.py
+++ b/pyterraformer/core/generics/interpolation.py
@@ -20,7 +20,7 @@ StringLit
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Optional, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, List, Optional
 
 if TYPE_CHECKING:
     from pyterraformer.core.namespace import TerraformFile
@@ -60,7 +60,7 @@ def variable_helper(arg, workspace, file, parent, parent_instance):
 
 class FileLookupInstantiator(Resolvable):
     def __init__(self, workspace: "TerraformWorkspace"):
-        for key, file in workspace.files.items():
+        for _key, file in workspace.files.items():
             for object in file.objects:
                 if hasattr(object, "tf_id"):
                     setattr(self, object.tf_id, object)
@@ -86,11 +86,7 @@ class FileObjectLookupInstantiator(Resolvable):
 
     def __getattr__(self, item):
         return FileObjectSubClassLookupInstantiator(
-            [
-                obj
-                for obj in self.objects
-                if hasattr(obj, "_type") and obj._type == str(item)
-            ]
+            [obj for obj in self.objects if hasattr(obj, "_type") and obj._type == str(item)]
         )
 
 
@@ -111,11 +107,7 @@ class DataLookupInstantiator(Resolvable):
 
     def __getattr__(self, item):
         return DataSubClassLookupInstantiator(
-            [
-                obj
-                for obj in self.workspace.data
-                if hasattr(obj, "type") and obj.type == str(item)
-            ]
+            [obj for obj in self.workspace.data if hasattr(obj, "type") and obj.type == str(item)]
         )
 
 
@@ -226,22 +218,21 @@ class ArrayLookup(Resolvable):
 
 
 class PropertyLookup(Resolvable):
-    def __init__(self, base, attributes: List):
+    def __init__(self, base, attributes: list):
         self.base = base
         self.contents = attributes
         self.property = attributes[0]
 
     def __repr__(self):
-        return "{}.{}".format(self.base.__repr__(), self.property.__repr__())
+        return f"{self.base.__repr__()}.{self.property.__repr__()}"
 
     def resolve(
         self,
         workspace: "TerraformWorkspace",
         file: "TerraformFile",
-        parent: Optional[Resolvable] = None,
-        parent_instance: Optional[Resolvable] = None,
+        parent: Resolvable | None = None,
+        parent_instance: Resolvable | None = None,
     ):
-
         anchor = parent or self.base
         if self.base == "module":
             anchor = FileLookupInstantiator(workspace)
@@ -261,11 +252,9 @@ class PropertyLookup(Resolvable):
         # in either case, pull out the base value and look that up immediately
         # then pass forward
 
-        if isinstance(self.property, (DictLookup, PropertyLookup)):
+        if isinstance(self.property, DictLookup | PropertyLookup):
             local_resolved = getattr(anchor, str(self.property.base))
-            return self.property.resolve(
-                workspace, file, parent=local_resolved, parent_instance=self
-            )
+            return self.property.resolve(workspace, file, parent=local_resolved, parent_instance=self)
         else:
             try:
                 return getattr(anchor, str(self.property))
@@ -274,7 +263,7 @@ class PropertyLookup(Resolvable):
 
 
 class StringLit(Resolvable):
-    def __init__(self, contents: List):
+    def __init__(self, contents: list):
         self.contents = contents
 
     @property
@@ -328,9 +317,7 @@ class String(Resolvable):
 
     def resolve(self, workspace, file, parent=None, parent_instance=None):
         if isinstance(parent_instance, PropertyLookup):
-            resolved = PropertyLookup(self.item).resolve(
-                workspace, file, parent, parent_instance
-            )
+            resolved = PropertyLookup(self.item).resolve(workspace, file, parent, parent_instance)
             return resolved
         return self.item
 
@@ -340,13 +327,11 @@ class File(Resolvable):
         self.item = item[0] if isinstance(item, list) else item
 
     def __repr__(self):
-        return "file({})".format(self.item.__repr__())
+        return f"file({self.item.__repr__()})"
 
     def resolve(self, workspace, file, parent=None, parent_instance=None):
         if isinstance(parent_instance, PropertyLookup):
-            resolved = PropertyLookup(self.item).resolve(
-                workspace, file, parent, parent_instance
-            )
+            resolved = PropertyLookup(self.item).resolve(workspace, file, parent, parent_instance)
             out = resolved
         else:
             out = self.item
@@ -364,16 +349,14 @@ class Concat(Resolvable):
         final = []
         for item in self.items:
             if isinstance(parent_instance, PropertyLookup):
-                resolved = PropertyLookup(item).resolve(
-                    workspace, file, parent, parent_instance
-                )
+                resolved = PropertyLookup(item).resolve(workspace, file, parent, parent_instance)
                 out = resolved
             elif isinstance(item, Resolvable):
                 out = item.resolve(workspace, file, None, None)
             else:
                 out = item
             final.append(out)
-        if all([isinstance(item, str) for item in final]):
+        if all(isinstance(item, str) for item in final):
             concat = "".join(final)
         else:
             concat = []
@@ -413,9 +396,7 @@ class Replace(Resolvable):
         final = []
         for item in self.items:
             if isinstance(parent_instance, PropertyLookup):
-                resolved = PropertyLookup(item).resolve(
-                    workspace, file, parent, parent_instance
-                )
+                resolved = PropertyLookup(item).resolve(workspace, file, parent, parent_instance)
                 out = resolved
             else:
                 out = item
@@ -430,17 +411,13 @@ class GenericFunction(Resolvable):
         self.items = items[1:]
 
     def __repr__(self):
-        return "{}({})".format(
-            self.name, ",".join([item.__repr__() for item in self.items])
-        )
+        return "{}({})".format(self.name, ",".join([item.__repr__() for item in self.items]))
 
     def resolve(self, workspace, file, parent=None, parent_instance=None):
         final = []
         for item in self.items:
             if isinstance(parent_instance, PropertyLookup):
-                resolved = PropertyLookup(item).resolve(
-                    workspace, file, parent, parent_instance
-                )
+                resolved = PropertyLookup(item).resolve(workspace, file, parent, parent_instance)
                 out = resolved
             else:
                 out = item
@@ -460,9 +437,7 @@ class Merge(Resolvable):
         final = []
         for item in self.items:
             if isinstance(parent_instance, PropertyLookup):
-                resolved = PropertyLookup(item).resolve(
-                    workspace, file, parent, parent_instance
-                )
+                resolved = PropertyLookup(item).resolve(workspace, file, parent, parent_instance)
                 out = resolved
             else:
                 out = item
@@ -535,9 +510,7 @@ class BinaryOp(Resolvable):
         left = all[0]
         operator, right = all[1]
         if isinstance(parent_instance, PropertyLookup):
-            left = PropertyLookup(left).resolve(
-                workspace, file, parent, parent_instance
-            )
+            left = PropertyLookup(left).resolve(workspace, file, parent, parent_instance)
         if operator == "==":
             return left == right
         elif operator == ">=":
@@ -571,9 +544,7 @@ class BinaryTerm(Resolvable):
         return "".join([val.__repr__() for val in self.args])
 
     def resolve(self, workspace, file, parent=None, parent_instance=None):
-        return [
-            item.resolve(workspace, file, parent, parent_instance) for item in self.args
-        ]
+        return [item.resolve(workspace, file, parent, parent_instance) for item in self.args]
 
 
 class Boolean(Resolvable):
@@ -678,9 +649,7 @@ class ToSet(Resolvable):
         final = []
         for item in self.items:
             if isinstance(parent_instance, PropertyLookup):
-                resolved = PropertyLookup(parent_instance, item).resolve(
-                    workspace, file, parent, parent_instance
-                )
+                resolved = PropertyLookup(parent_instance, item).resolve(workspace, file, parent, parent_instance)
                 out = resolved
             else:
                 out = item

--- a/pyterraformer/core/generics/literal.py
+++ b/pyterraformer/core/generics/literal.py
@@ -1,4 +1,4 @@
-class Literal(object):
+class Literal:
     def __init__(self, str):
         self.value = str
 

--- a/pyterraformer/core/generics/local.py
+++ b/pyterraformer/core/generics/local.py
@@ -7,9 +7,7 @@ class Local(TerraformObject):
         for key, value in attributes.items():
             pass_on.append([key, value])
 
-        TerraformObject.__init__(
-            self, _type="local", original_text=text, attributes=pass_on
-        )
+        TerraformObject.__init__(self, _type="local", original_text=text, attributes=pass_on)
 
     # def render(self, variables=None):
     #     from analytics_terraformer_core.utility import clean_render_dictionary

--- a/pyterraformer/core/generics/meta_arguments.py
+++ b/pyterraformer/core/generics/meta_arguments.py
@@ -1,21 +1,18 @@
 # from analytics_utility_core.decorators import lazy_property
 
 from typing import Optional
-from pyterraformer.core.objects import TerraformObject, ObjectMetadata
+
+from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 
 class Provider(TerraformObject):
-    def __init__(self, type: str, _metadata: Optional[ObjectMetadata] = None, **kwargs):
+    def __init__(self, type: str, _metadata: ObjectMetadata | None = None, **kwargs):
         self.ptype = str(type).replace('"', "")
         TerraformObject.__init__(self, _type="provider", _metadata=_metadata)
 
     def __repr__(self):
         return (
-            f"{self._type}-{self.ptype}("
-            + ", ".join(
-                [f'{key}="{val}"' for key, val in self.render_variables.items()]
-            )
-            + ")"
+            f"{self._type}-{self.ptype}(" + ", ".join([f'{key}="{val}"' for key, val in self.render_variables.items()]) + ")"
         )
 
     # def render(self, variables=None):

--- a/pyterraformer/core/generics/terraform.py
+++ b/pyterraformer/core/generics/terraform.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from pyterraformer.core.objects import TerraformObject, ObjectMetadata
+from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 
 class TerraformConfig(TerraformObject):
-    def __init__(self, _metadata: Optional[ObjectMetadata] = None, **kwargs):
+    def __init__(self, _metadata: ObjectMetadata | None = None, **kwargs):
         # self.backends = [obj for obj in attributes if isinstance(obj, Backend)]
         TerraformObject.__init__(self, "terraform", _metadata=_metadata, **kwargs)
 

--- a/pyterraformer/core/generics/variables.py
+++ b/pyterraformer/core/generics/variables.py
@@ -1,5 +1,6 @@
-from pyterraformer.core.objects import TerraformObject
 from typing import TYPE_CHECKING
+
+from pyterraformer.core.objects import TerraformObject
 
 if TYPE_CHECKING:
     from pyterraformer.core.generics import Literal
@@ -13,15 +14,12 @@ class Variable(TerraformObject):
     def __repr__(self):
         return (
             f"{self._type}(name={self.name}, "
-            + ", ".join(
-                [f'{key}="{val}"' for key, val in self.render_variables.items()]
-            )
+            + ", ".join([f'{key}="{val}"' for key, val in self.render_variables.items()])
             + ")"
         )
 
     def __getitem__(self, val):
         for key, item in self.default.items():
-
             if val == key:
                 return item
         raise KeyError(val)
@@ -41,15 +39,15 @@ class Variable(TerraformObject):
 
         return Literal(f"var.{self.name}")
 
-    def get(self, val, fallback: str = None):
+    def get(self, val, fallback: str | None = None):
         for key, item in self.default.items():
             if val == key:
                 return item
         return fallback
 
     def get_type(self, val) -> "Literal":
-        from pyterraformer.core.generics.interpolation import String
         from pyterraformer.core.generics import Literal, StringLit
+        from pyterraformer.core.generics.interpolation import String
 
         if isinstance(val, list):
             if not val:

--- a/pyterraformer/core/modules.py
+++ b/pyterraformer/core/modules.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-from pyterraformer.core.objects import TerraformObject, ObjectMetadata
+from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 
 class ModuleObject(TerraformObject):
-    def __init__(self, tf_id, _metadata: Optional[ObjectMetadata] = None, **kwargs):
+    def __init__(self, tf_id, _metadata: ObjectMetadata | None = None, **kwargs):
         TerraformObject.__init__(self, _type="module", tf_id=tf_id, **kwargs)

--- a/pyterraformer/core/namespace.py
+++ b/pyterraformer/core/namespace.py
@@ -1,27 +1,27 @@
 import os
 from pathlib import Path
-from typing import Dict, List, Union, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
+from pyterraformer.core.utility import value_match
 from pyterraformer.enums import InsertPosition
 from pyterraformer.serializer import BaseSerializer
-from pyterraformer.core.utility import value_match
 
 if TYPE_CHECKING:
-    from pyterraformer.core.workspace import TerraformWorkspace
     from pyterraformer.core import TerraformObject
+    from pyterraformer.core.workspace import TerraformWorkspace
 
 
-class TerraformNamespace(object):
+class TerraformNamespace:
     def __init__(
         self,
         name: str,
         workspace: "TerraformWorkspace",
-        objects: Optional[List["TerraformObject"]] = None,
+        objects: list["TerraformObject"] | None = None,
     ):
-        self.workspace: "TerraformWorkspace" = workspace
+        self.workspace: TerraformWorkspace = workspace
         self.name = name
-        self.objects: List = objects or []
-        self.locals: Dict = {}
+        self.objects: list = objects or []
+        self.locals: dict = {}
 
     def resolve(self):
         """No op for the base file"""
@@ -29,10 +29,8 @@ class TerraformNamespace(object):
 
 
 class LazyFile(TerraformNamespace):
-    def __init__(self, file: Union[str, Path], workspace: "TerraformWorkspace"):
-        super().__init__(
-            name=os.path.basename(file).replace(".tf", ""), workspace=workspace
-        )
+    def __init__(self, file: str | Path, workspace: "TerraformWorkspace"):
+        super().__init__(name=os.path.basename(file).replace(".tf", ""), workspace=workspace)
         self.file = file
 
     def resolve(self) -> "TerraformFile":
@@ -46,8 +44,8 @@ class TerraformFile(TerraformNamespace):
         self,
         workspace: "TerraformWorkspace",
         text: str,
-        location: Union[str, Path],
-        objects: Optional[List["TerraformObject"]] = None,
+        location: str | Path,
+        objects: list["TerraformObject"] | None = None,
     ):
         self._text = text
         name = os.path.basename(location)
@@ -58,16 +56,9 @@ class TerraformFile(TerraformNamespace):
 
     def get_object(self, **kwargs):
         for object in self.objects:
-            if all(
-                [
-                    value_match(getattr(object, key, None), val)
-                    for key, val in kwargs.items()
-                ]
-            ):
+            if all(value_match(getattr(object, key, None), val) for key, val in kwargs.items()):
                 return object
-        raise ValueError(
-            f"No object matching filter criteria {kwargs} found in file {self.location}"
-        )
+        raise ValueError(f"No object matching filter criteria {kwargs} found in file {self.location}")
 
     def delete_object(self, object):
         orig = self.objects
@@ -83,28 +74,25 @@ class TerraformFile(TerraformNamespace):
             return reversed(output)
         return output
 
-    def _detect_duplicates(self, object) -> List:
-        from pyterraformer.core.resources import ResourceObject
+    def _detect_duplicates(self, object) -> list:
+        from pyterraformer.core.generics import Data, Variable
         from pyterraformer.core.modules import ModuleObject
-        from pyterraformer.core.generics import Variable, Data
+        from pyterraformer.core.resources import ResourceObject
 
         duplicates = []
-        if isinstance(object, (Variable, Data)):
+        if isinstance(object, Variable | Data):
             duplicates = [
                 idx
                 for idx, obj in enumerate(self.objects)
-                if isinstance(object, (Variable, Data))
-                and object.name == getattr(obj, "name", "")
+                if isinstance(object, Variable | Data) and object.name == getattr(obj, "name", "")
             ]
         elif isinstance(object, ResourceObject):
-
             duplicates = [
                 idx
                 for idx, obj in enumerate(self.objects)
                 if isinstance(object, ResourceObject)
                 and object.tf_id
-                and object.tf_id + (object._type or "")
-                == getattr(obj, "tf_id", "") + getattr(obj, "_type", "")
+                and object.tf_id + (object._type or "") == getattr(obj, "tf_id", "") + getattr(obj, "_type", "")
             ]
         elif isinstance(object, ModuleObject):
             duplicates = [
@@ -112,15 +100,14 @@ class TerraformFile(TerraformNamespace):
                 for idx, obj in enumerate(self.objects)
                 if isinstance(object, ModuleObject)
                 and object.tf_id
-                and object.tf_id + (object._type or "")
-                == getattr(obj, "tf_id", "") + getattr(obj, "_type", "")
+                and object.tf_id + (object._type or "") == getattr(obj, "tf_id", "") + getattr(obj, "_type", "")
             ]
         return duplicates
 
     def add_object(
         self,
         object: "TerraformObject",
-        position: Union[InsertPosition, int] = InsertPosition.DEFAULT,
+        position: InsertPosition | int = InsertPosition.DEFAULT,
         exists_okay: bool = False,
         replace: bool = False,
     ):
@@ -128,11 +115,7 @@ class TerraformFile(TerraformNamespace):
         duplicates = self._detect_duplicates(object)
         if duplicates:
             if replace:
-                self.objects = [
-                    obj
-                    for idx, obj in enumerate(self.objects)
-                    if idx not in (duplicates)
-                ]
+                self.objects = [obj for idx, obj in enumerate(self.objects) if idx not in (duplicates)]
             elif exists_okay:
                 return
             else:
@@ -145,9 +128,7 @@ class TerraformFile(TerraformNamespace):
         elif position == InsertPosition.LAST:
             self.objects.append(object)
         elif position == InsertPosition.DEFAULT:
-            indexes = [
-                idx for idx, val in enumerate(self.objects) if val._type == object._type
-            ]
+            indexes = [idx for idx, val in enumerate(self.objects) if val._type == object._type]
             if indexes:
                 self.objects.insert(indexes[-1] + 1, object)
             else:

--- a/pyterraformer/core/objects.py
+++ b/pyterraformer/core/objects.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Optional
 
 from pyterraformer.exceptions import ValidationError
-
 
 if TYPE_CHECKING:
     from pyterraformer.core.namespace import TerraformNamespace
@@ -10,28 +9,25 @@ if TYPE_CHECKING:
 
 @dataclass
 class ObjectMetadata:
-    source_file: Optional[str] = None
-    orig_text: Optional[str] = None
-    row_num: Optional[int] = None
-    start_pos: Optional[int] = None
-    end_pos: Optional[int] = None
+    source_file: str | None = None
+    orig_text: str | None = None
+    row_num: int | None = None
+    start_pos: int | None = None
+    end_pos: int | None = None
 
 
-class TerraformObject(object):
+class TerraformObject:
     def __init__(
         self,
         _type,
-        tf_id: Optional[str] = None,
-        _metadata: Optional[ObjectMetadata] = None,
+        tf_id: str | None = None,
+        _metadata: ObjectMetadata | None = None,
         **kwargs,
     ):
-
         self._metadata = _metadata or ObjectMetadata()
         self.tf_id = tf_id
         arguments = kwargs or {}
-        self.render_variables: Dict[str, str] = {
-            str(key): value for key, value in arguments.items()
-        }
+        self.render_variables: dict[str, str] = {str(key): value for key, value in arguments.items()}
         # for attribute in self.attributes:
         #     if isinstance(attribute, list):
         #         # always cast keys to string
@@ -43,17 +39,11 @@ class TerraformObject(object):
         self._type: str = _type
         self._changed: bool = False
         self._workspace = None
-        self._file: Optional["TerraformNamespace"] = None
+        self._file: TerraformNamespace | None = None
         self._initialized: bool = True
 
     def __repr__(self):
-        return (
-            f"{self._type}("
-            + ", ".join(
-                [f'{key}="{val}"' for key, val in self.render_variables.items()]
-            )
-            + ")"
-        )
+        return f"{self._type}(" + ", ".join([f'{key}="{val}"' for key, val in self.render_variables.items()]) + ")"
 
     @property
     def tf_attributes(self):
@@ -86,13 +76,10 @@ class TerraformObject(object):
         So skip anything with a private method, or in the disallow list...
         Unless it's also in the list of things that we should render."""
         if name.startswith("_") or (
-            name in ("row_num", "template", "name", "tf_id")
-            and not (self.render_variables and name in self.render_variables)
+            name in ("row_num", "template", "name", "tf_id") and not (self.render_variables and name in self.render_variables)
         ):
             super().__setattr__(name, value)
-        elif (self.render_variables and name in self.render_variables) or getattr(
-            self, "_initialized", False
-        ):
+        elif (self.render_variables and name in self.render_variables) or getattr(self, "_initialized", False):
             self._changed = True
             self.__dict__.get("render_variables")[name] = value
         else:
@@ -119,14 +106,11 @@ class TerraformObject(object):
         elif isinstance(item, int):
             resolved = item
         elif isinstance(item, dict):
-            resolved = {
-                self.resolve_item(key): self.resolve_item(value)
-                for key, value in item.items()
-            }
+            resolved = {self.resolve_item(key): self.resolve_item(value) for key, value in item.items()}
         else:
             resolved = item.resolve(self._workspace, self._file, None, None)
         if isinstance(resolved, Variable) and hasattr(resolved, "default"):
-            resolved = getattr(resolved, "default")
+            resolved = resolved.default
         return resolved
 
     @property

--- a/pyterraformer/core/resources/resource_object.py
+++ b/pyterraformer/core/resources/resource_object.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
-from pyterraformer.core.objects import TerraformObject, ObjectMetadata
+from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 
 @dataclass
@@ -11,14 +11,12 @@ class StateResponse:
 
 
 class ResourceObject(TerraformObject):
-    REQUIRED_ATTRIBUTES: List[str] = []
-    PRIORITY_ATTRIBUTES: List[str] = []
-    BLOCK_ATTRIBUTES: List[str] = []
+    REQUIRED_ATTRIBUTES: list[str] = []
+    PRIORITY_ATTRIBUTES: list[str] = []
+    BLOCK_ATTRIBUTES: list[str] = []
     _type = "generic_resource_object"
 
-    def __init__(
-        self, tf_id: str, _metadata: Optional[ObjectMetadata] = None, **kwargs
-    ):
+    def __init__(self, tf_id: str, _metadata: ObjectMetadata | None = None, **kwargs):
         TerraformObject.__init__(self, self._type, tf_id, _metadata=_metadata, **kwargs)
 
     def render_attribute(self, item):

--- a/pyterraformer/core/utility.py
+++ b/pyterraformer/core/utility.py
@@ -1,11 +1,12 @@
 import os
+from collections.abc import Iterator
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Iterator, List, Union
+from typing import List, Union
 
 
 def splitall(path: str) -> Iterator[str]:
-    out: List[str] = []
+    out: list[str] = []
     while True:
         base, end = os.path.split(path)
         if base and end:
@@ -17,7 +18,7 @@ def splitall(path: str) -> Iterator[str]:
     return reversed(out)
 
 
-def get_root(path: str, breaker: Union[str, List[str]] = None):
+def get_root(path: str, breaker: str | list[str] | None = None):
     if isinstance(breaker, str):
         breaker = [breaker]
     elif not breaker:

--- a/pyterraformer/core/workspace.py
+++ b/pyterraformer/core/workspace.py
@@ -3,18 +3,17 @@ from collections import defaultdict
 from fnmatch import fnmatch
 from os.path import dirname
 from pathlib import Path, PurePath
-from typing import Dict, List, Union, Any
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from pyterraformer.constants import logger
-from pyterraformer.core.generics import Literal, BlockList
+from pyterraformer.core.generics import BlockList, Literal
 from pyterraformer.core.utility import get_root
 from pyterraformer.serializer import BaseSerializer
 from pyterraformer.terraform import Terraform
 
 if TYPE_CHECKING:
-    from pyterraformer.core.namespace import TerraformFile
     from pyterraformer.core.generics.variables import Variable
+    from pyterraformer.core.namespace import TerraformFile
 
 
 def process_attribute(input: Any, level=0):
@@ -25,7 +24,7 @@ def process_attribute(input: Any, level=0):
 
     if not isinstance(input, dict):
         return input
-    output: Dict[str, Any] = {}
+    output: dict[str, Any] = {}
     for key, item in input.items():
         if isinstance(item, Variable):
             output[key] = item.render_basic()
@@ -38,7 +37,7 @@ def process_attribute(input: Any, level=0):
                 output[f"{key}~~block_{idx}"] = process_attribute(sub_item)
         elif isinstance(item, dict):
             output[key] = process_attribute(item)
-        elif isinstance(item, List):
+        elif isinstance(item, list):
             output[key] = [process_attribute(sub_item) for sub_item in item]
         else:
             output[key] = item
@@ -81,33 +80,30 @@ class LazyFileDict(dict):
 
 
 def extract_errors(input: str):
-    found = re.findall(
-        r"(Error:.*)(?:Error:|$)", input, re.IGNORECASE | re.MULTILINE | re.DOTALL
-    )
+    found = re.findall(r"(Error:.*)(?:Error:|$)", input, re.IGNORECASE | re.MULTILINE | re.DOTALL)
     return "\n".join(found).strip()
 
 
-class TerraformWorkspace(object):
+class TerraformWorkspace:
     def __init__(
         self,
-        path: Union[str, PurePath],
-        terraform: Optional[Terraform] = None,
-        serializer: Optional[BaseSerializer] = None,
-        files: Optional[List["TerraformFile"]] = None,
-        children: Optional[List["TerraformWorkspace"]] = None,
+        path: str | PurePath,
+        terraform: Terraform | None = None,
+        serializer: BaseSerializer | None = None,
+        files: list["TerraformFile"] | None = None,
+        children: list["TerraformWorkspace"] | None = None,
     ):
-
         self.terraform = terraform
         self.path = str(path)
         self._path = Path(self.path)
-        self.files: Dict[str, TerraformFile] = LazyFileDict()
+        self.files: dict[str, TerraformFile] = LazyFileDict()
         if files:
             for file in files:
                 self.files[file.name] = files
-        self.children: List[TerraformWorkspace] = children or []
+        self.children: list[TerraformWorkspace] = children or []
         self.name = self._path.stem
-        self.variables: Dict[str, "Variable"] = {}
-        self.data: List = []
+        self.variables: dict[str, Variable] = {}
+        self.data: list = []
         self.serializer = serializer
 
     def apply(self):
@@ -130,22 +126,17 @@ class TerraformWorkspace(object):
                     raise FileNotFoundError("No valid serializer found.")
                 file = self.serializer.parse_file(self._path / name, self)
             except FileNotFoundError:
-                file = TerraformFile(
-                    workspace=self, text="", location=self._path / name
-                )
+                file = TerraformFile(workspace=self, text="", location=self._path / name)
 
             self.files[name] = file
 
         return self.files[name]
 
     def get_terraform_config(self):
-        from pyterraformer.core.generics import TerraformConfig
-        from pyterraformer.core.generics import BlockList
+        from pyterraformer.core.generics import BlockList, TerraformConfig
 
         terraform = self.get_file_safe("terraform.tf")
-        existing = [
-            obj for obj in terraform.objects if isinstance(obj, TerraformConfig)
-        ]
+        existing = [obj for obj in terraform.objects if isinstance(obj, TerraformConfig)]
         if existing:
             return existing[0]
         logger.info("creating new terraform config")
@@ -176,15 +167,11 @@ class TerraformWorkspace(object):
             return nfile
 
     def add_child_workspace(self, path: str):
-        child = TerraformWorkspace(
-            path=path, serializer=self.serializer, terraform=self.terraform
-        )
+        child = TerraformWorkspace(path=path, serializer=self.serializer, terraform=self.terraform)
         self.children.append(child)
         setattr(self, child.name, child)
 
-    def add_variable(
-        self, key: str, values, exists_okay: bool = False, replace: bool = False
-    ):
+    def add_variable(self, key: str, values, exists_okay: bool = False, replace: bool = False):
         from pyterraformer.core.generics.variables import Variable
 
         if key in self.variables:
@@ -209,9 +196,7 @@ class TerraformWorkspace(object):
         self.variables[key] = variable
         # create if not exists
         if "variables.tf" not in self.files:
-            self.files["variables.tf"] = TerraformFile(
-                self, "", self._path / "variables.tf"
-            )
+            self.files["variables.tf"] = TerraformFile(self, "", self._path / "variables.tf")
 
         self.files["variables.tf"].add_object(variable, replace=replace)
         return variable
@@ -231,7 +216,7 @@ class TerraformWorkspace(object):
         if not self.serializer:
             raise ValueError("Cannot save without serializer defined.")
         format = False
-        for key, file in self.files.items(resolve=False):  # type: ignore
+        for _key, file in self.files.items(resolve=False):  # type: ignore
             # skip files we never touched
             if isinstance(file, LazyFile):
                 logger.info("Skipping lazily unparsed file")
@@ -276,14 +261,12 @@ class TerraformWorkspace(object):
         return output
 
     def get_object(self, **kwargs):
-        for key, file in self.files.items():
+        for _key, file in self.files.items():
             try:
                 return file.get_object(**kwargs)
             except ValueError:
                 pass
-        raise ValueError(
-            f"No object matching filter criteria {kwargs} found in any files in {self.path}"
-        )
+        raise ValueError(f"No object matching filter criteria {kwargs} found in any files in {self.path}")
 
 
 def value_match(item: Any, value: Any) -> bool:

--- a/pyterraformer/inventory.py
+++ b/pyterraformer/inventory.py
@@ -1,3 +1,5 @@
 class ResourceRegistry(dict):
-    def __init__(self,):
+    def __init__(
+        self,
+    ):
         super().__init__()

--- a/pyterraformer/serializer/base_serializer.py
+++ b/pyterraformer/serializer/base_serializer.py
@@ -1,15 +1,15 @@
-from typing import Optional, Dict, TYPE_CHECKING, Union
 from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 if TYPE_CHECKING:
     from pyterraformer.core import (
-        TerraformWorkspace,
-        TerraformObject,
         TerraformNamespace,
+        TerraformObject,
+        TerraformWorkspace,
     )
 
 
-class BaseSerializer(object):
+class BaseSerializer:
     pass
 
     @property
@@ -19,23 +19,19 @@ class BaseSerializer(object):
     def parse_string(self, string: str):
         raise NotImplementedError
 
-    def parse_file(self, path: Union[str, Path], workspace: "TerraformWorkspace"):
+    def parse_file(self, path: str | Path, workspace: "TerraformWorkspace"):
         raise NotImplementedError
 
     def _format_string(self, string: str):
         raise NotImplementedError
 
-    def render_object(
-        self, object: "TerraformObject", format: Optional[bool] = None
-    ) -> str:
+    def render_object(self, object: "TerraformObject", format: bool | None = None) -> str:
         raise NotImplementedError
 
-    def render_namespace(
-        self, namespace: "TerraformNamespace", format: Optional[bool] = None
-    ) -> str:
+    def render_namespace(self, namespace: "TerraformNamespace", format: bool | None = None) -> str:
         raise NotImplementedError
 
-    def render_workspace(self, workspace: "TerraformWorkspace") -> Dict[str, str]:
+    def render_workspace(self, workspace: "TerraformWorkspace") -> dict[str, str]:
         raise NotImplementedError
 
     #

--- a/pyterraformer/serializer/human_resources/engine.py
+++ b/pyterraformer/serializer/human_resources/engine.py
@@ -1,47 +1,47 @@
-from typing import Dict, Tuple, Any
+import builtins
+from typing import Any, Dict, List, Tuple
 
 from lark import Lark, Transformer, v_args
 from lark.tree import Meta
 
 from pyterraformer.core.generics import (
-    Comment,
-    Variable,
-    Interpolation,
-    String,
-    StringLit,
-    DictLookup,
-    PropertyLookup,
-    TerraformConfig,
-    Provider,
-    BinaryTerm,
-    Data,
-    Expression,
-    Conditional,
+    ArrayLookup,
     BinaryOp,
     BinaryOperator,
-    Output,
-    Local,
-    Parenthetical,
-    LegacySplat,
+    BinaryTerm,
     BlockList,
-    File,
     Boolean,
-    Merge,
+    Comment,
     Concat,
-    Types,
-    Replace,
-    ArrayLookup,
+    Conditional,
+    Data,
+    DictLookup,
+    Expression,
+    File,
     GenericFunction,
+    Interpolation,
+    LegacySplat,
+    Local,
+    Merge,
+    Output,
+    Parenthetical,
+    PropertyLookup,
+    Provider,
+    Replace,
+    String,
+    StringLit,
     Symlink,
+    TerraformConfig,
     ToSet,
+    Types,
+    Variable,
 )
 from pyterraformer.core.modules import ModuleObject
 from pyterraformer.core.objects import ObjectMetadata, TerraformObject
-from typing import List
 
 # TODO: rewrite to comply with https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md
 
-RESOURCES_MAP: Dict = {}
+RESOURCES_MAP: dict = {}
 
 grammar = r"""
     start: ( item | symlink)*
@@ -61,9 +61,9 @@ grammar = r"""
     symlink: "."+ "/" /[a-zA-Z_\-]+/ ".tf"
 
     resource: "resource" string_lit string_lit  "{" (nested_comment| sub_object | lifecycle | provider | split_subarray ) + "}"
-    
+
     nested_comment: comment
-    
+
     output: "output" string_lit "{"[( nested_comment| sub_object)+] "}"
 
     module: "module" string_lit  "{"  (nested_comment | sub_object | split_subarray)+ "}"
@@ -212,8 +212,8 @@ grammar = r"""
 """
 
 
-def args_to_dict(input_list: list) -> Dict[str, Any]:
-    output: Dict[str, Any] = {}
+def args_to_dict(input_list: list) -> dict[str, Any]:
+    output: dict[str, Any] = {}
     for array in input_list:
         key = array[0]
         val = array[1]
@@ -310,9 +310,7 @@ class ParseToObjects(Transformer):
     def terraform(self, meta: Meta, args):
         from pyterraformer.core.objects import ObjectMetadata
 
-        metadata = ObjectMetadata(
-            orig_text=self.meta_to_text(meta), row_num=meta.start_pos
-        )
+        metadata = ObjectMetadata(orig_text=self.meta_to_text(meta), row_num=meta.start_pos)
 
         parsed = args_to_dict(args)
         return TerraformConfig(_metadata=metadata, **parsed)
@@ -343,9 +341,7 @@ class ParseToObjects(Transformer):
 
     @v_args(meta=True)
     def multiline_comment(self, meta: Meta, args):
-        metadata = ObjectMetadata(
-            orig_text=self.meta_to_text(meta), row_num=meta.start_pos
-        )
+        metadata = ObjectMetadata(orig_text=self.meta_to_text(meta), row_num=meta.start_pos)
         base = args[0].value
         if len(args) > 1:
             base += args[1].value
@@ -356,9 +352,7 @@ class ParseToObjects(Transformer):
     def backend(self, meta: Meta, args):
         from pyterraformer.core.generics import Backend
 
-        metadata = ObjectMetadata(
-            orig_text=self.meta_to_text(meta), row_num=meta.start_pos
-        )
+        metadata = ObjectMetadata(orig_text=self.meta_to_text(meta), row_num=meta.start_pos)
         return "backend", Backend(args[0], _metadata=metadata)
 
     def output(self, args):
@@ -443,7 +437,7 @@ class ParseToObjects(Transformer):
     def bool_token(self, args):
         return str(args[0].value)
 
-    def split_subarray(self, args: list) -> Tuple[str, BlockList]:
+    def split_subarray(self, args: list) -> builtins.tuple[str, BlockList]:
         name = args[0]
         return (
             name,
@@ -461,7 +455,5 @@ class ParseToObjects(Transformer):
 TERRAFORM_PARSER = Lark(grammar, start="start", propagate_positions=True)
 
 
-def parse_text(text: str) -> List[TerraformObject]:
-    return ParseToObjects(visit_tokens=True, text=text).transform(
-        TERRAFORM_PARSER.parse(text)
-    )
+def parse_text(text: str) -> list[TerraformObject]:
+    return ParseToObjects(visit_tokens=True, text=text).transform(TERRAFORM_PARSER.parse(text))

--- a/pyterraformer/serializer/human_resources/module.py
+++ b/pyterraformer/serializer/human_resources/module.py
@@ -5,8 +5,8 @@ from pyterraformer.core.objects import TerraformObject
 
 
 class BaseModule(TerraformObject):
-    REQUIRED_ATTRIBUTES: List[str] = []
-    PRIORITY_ATTRIBUTES: List[str] = []
+    REQUIRED_ATTRIBUTES: list[str] = []
+    PRIORITY_ATTRIBUTES: list[str] = []
 
     def __init__(self, text, name, attributes):
         self._name = str(name).replace('"', "")

--- a/pyterraformer/serializer/human_serializer.py
+++ b/pyterraformer/serializer/human_serializer.py
@@ -1,40 +1,37 @@
-from os.path import join, dirname
+from dataclasses import asdict, is_dataclass
+from os.path import dirname, join
 from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
-from typing import Optional, Dict, Union, TYPE_CHECKING, Any, List
-from dataclasses import is_dataclass, asdict
-
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import jinja2
 
-from pyterraformer.constants import logger, EMPTY_DEFAULT
+from pyterraformer.constants import EMPTY_DEFAULT, logger
 from pyterraformer.core.generics import Backend, Comment
 from pyterraformer.core.modules import ModuleObject
 from pyterraformer.core.resources import ResourceObject
+from pyterraformer.exceptions import TerraformExecutionError
 from pyterraformer.serializer.base_serializer import BaseSerializer
 from pyterraformer.serializer.human_resources.engine import parse_text
-from pyterraformer.exceptions import TerraformExecutionError
 
 if TYPE_CHECKING:
-    from pyterraformer.terraform import Terraform
     from pyterraformer.core import (
-        TerraformWorkspace,
-        TerraformObject,
-        TerraformNamespace,
         TerraformFile,
+        TerraformNamespace,
+        TerraformObject,
+        TerraformWorkspace,
     )
+    from pyterraformer.terraform import Terraform
 
 TEMPLATE_PATH = join(dirname(__file__), "templates")
 
 template_loader = jinja2.FileSystemLoader(searchpath=TEMPLATE_PATH)
-env = jinja2.Environment(
-    loader=template_loader, autoescape=True, keep_trailing_newline=True
-)
+env = jinja2.Environment(loader=template_loader, autoescape=True, keep_trailing_newline=True)
 
 
 def process_attribute(input: Any):
-    from pyterraformer.core.generics import Variable, Literal, BlockList, BlockSet
+    from pyterraformer.core.generics import BlockList, BlockSet, Literal, Variable
 
     valid = False
     if isinstance(input, dict) or is_dataclass(input):
@@ -42,11 +39,11 @@ def process_attribute(input: Any):
     if not valid:
         return input
 
-    if is_dataclass(input):
+    if is_dataclass(input) and not isinstance(input, type):
         final_input = asdict(input)
     else:
         final_input = input
-    output: Dict[str, Any] = {}
+    output: dict[str, Any] = {}
     for key, item in final_input.items():
         if item == EMPTY_DEFAULT:
             continue
@@ -56,16 +53,16 @@ def process_attribute(input: Any):
             output[key] = item
         elif str(key).startswith("comment-") and isinstance(item, Comment):
             output[key] = Literal(item.text)
-        elif isinstance(item, (BlockList, BlockSet)):
+        elif isinstance(item, BlockList | BlockSet):
             for idx, sub_item in enumerate(item):  # type: ignore
                 output[f"{key}~~block_{idx}"] = process_attribute(sub_item)
-        elif is_dataclass(item):
+        elif is_dataclass(item) and not isinstance(item, type):
             output[f"{key}~~block_0"] = process_attribute(asdict(item))
         elif isinstance(item, Backend):
             output[f"{key}~~block_0"] = process_attribute(item)
         elif isinstance(item, dict):
             output[key] = process_attribute(item)
-        elif isinstance(item, List):
+        elif isinstance(item, list):
             output[key] = [process_attribute(sub_item) for sub_item in item]
         else:
             output[key] = item
@@ -73,10 +70,10 @@ def process_attribute(input: Any):
 
 
 class HumanSerializer(BaseSerializer):
-    def __init__(self, terraform: Optional[Union[str, "Terraform"]] = None):
+    def __init__(self, terraform: Union[str, "Terraform"] | None = None):
         from pyterraformer.terraform import Terraform
 
-        self.terraform: Optional[Terraform] = None
+        self.terraform: Terraform | None = None
         if isinstance(terraform, Terraform):
             self.terraform = terraform
         elif terraform:
@@ -93,15 +90,13 @@ class HumanSerializer(BaseSerializer):
     def parse_string(self, string: str):
         return parse_text(string)
 
-    def parse_file(self, path: Union[str, Path], workspace: "TerraformWorkspace"):
+    def parse_file(self, path: str | Path, workspace: "TerraformWorkspace"):
         from pyterraformer.core.namespace import TerraformFile
 
-        with open(path, "r") as f:
+        with open(path) as f:
             text = f.read()
             objects = self.parse_string(string=text)
-        return TerraformFile(
-            location=path, workspace=workspace, objects=objects, text=text
-        )
+        return TerraformFile(location=path, workspace=workspace, objects=objects, text=text)
 
     def _format_string(self, string: str) -> str:
         if not self.terraform:
@@ -122,9 +117,7 @@ class HumanSerializer(BaseSerializer):
                 raise e
             return file_name.open().read()
 
-    def render_object(
-        self, object: "TerraformObject", format: Optional[bool] = None
-    ) -> str:
+    def render_object(self, object: "TerraformObject", format: bool | None = None) -> str:
         if format and not self.can_format:
             raise ValueError("No terraform executable configured, cannot format.")
         from pyterraformer.core.generics import TerraformConfig
@@ -149,17 +142,13 @@ class HumanSerializer(BaseSerializer):
         # print(final)
         # print(process_attribute(final))
         # raise ValueError
-        string = template.render(
-            render_attributes=process_attribute(final), **variables
-        )
+        string = template.render(render_attributes=process_attribute(final), **variables)
 
         if format:
             string = self._format_string(string)
         return string
 
-    def render_namespace(
-        self, namespace: "TerraformNamespace", format: Optional[bool] = None
-    ) -> str:
+    def render_namespace(self, namespace: "TerraformNamespace", format: bool | None = None) -> str:
         from pyterraformer.core.generics import Comment
 
         format = format if format is not None else self.can_format
@@ -180,9 +169,7 @@ class HumanSerializer(BaseSerializer):
             return self._format_string(string)
         return "".join(out)
 
-    def render_workspace(
-        self, workspace: "TerraformWorkspace", format: Optional[bool] = None
-    ) -> Dict[str, str]:
+    def render_workspace(self, workspace: "TerraformWorkspace", format: bool | None = None) -> dict[str, str]:
         format = format if format is not None else self.can_format
         output = {}
         for name, file in workspace.files.items():

--- a/pyterraformer/serializer/load_templates.py
+++ b/pyterraformer/serializer/load_templates.py
@@ -4,9 +4,7 @@ import jinja2
 
 TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "templates")
 template_loader = jinja2.FileSystemLoader(searchpath=TEMPLATE_PATH)
-env = jinja2.Environment(
-    loader=template_loader, autoescape=True, keep_trailing_newline=True
-)
+env = jinja2.Environment(loader=template_loader, autoescape=True, keep_trailing_newline=True)
 
 
 def get_template(name: str):

--- a/pyterraformer/settings.py
+++ b/pyterraformer/settings.py
@@ -2,7 +2,7 @@ from os import environ
 from typing import Optional
 
 
-def get_default_terraform_location() -> Optional[str]:
+def get_default_terraform_location() -> str | None:
     """Attempt to discover default terraform location"""
     declared_path = environ.get("TERRAFORM_EXEC", None)
     if declared_path:

--- a/pyterraformer/terraform/backends/base_backend.py
+++ b/pyterraformer/terraform/backends/base_backend.py
@@ -6,7 +6,7 @@ from pyterraformer.core.generics import Backend
 
 @dataclass
 class BaseBackend:
-    SECRET_FIELDS: ClassVar = []
+    SECRET_FIELDS: ClassVar[list[str]] = []
 
     def generate_environment(self) -> dict:
         return {}

--- a/pyterraformer/terraform/backends/base_backend.py
+++ b/pyterraformer/terraform/backends/base_backend.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, ClassVar
+from typing import ClassVar, Dict
 
 from pyterraformer.core.generics import Backend
 
@@ -8,7 +8,7 @@ from pyterraformer.core.generics import Backend
 class BaseBackend:
     SECRET_FIELDS: ClassVar = []
 
-    def generate_environment(self) -> Dict:
+    def generate_environment(self) -> dict:
         return {}
 
     def as_object(self) -> Backend:

--- a/pyterraformer/terraform/backends/gcs_backend.py
+++ b/pyterraformer/terraform/backends/gcs_backend.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List, Dict, ClassVar
+from typing import ClassVar, Dict, List, Optional
 
 from pyterraformer.terraform.backends.base_backend import BaseBackend
 
@@ -8,24 +8,22 @@ from pyterraformer.terraform.backends.base_backend import BaseBackend
 class GCSBackend(BaseBackend):
     """Stores the state as an object in a configurable prefix in a pre-existing bucket on Google Cloud Storage (GCS). The bucket must exist prior to configuring the backend."""
 
-    credentials: Optional[str] = None
-    impersonate_service_account: Optional[str] = None
-    impersonate_service_account_delegations: Optional[List[str]] = None
-    access_token: Optional[str] = None
-    prefix: Optional[str] = None
-    encryption_key: Optional[str] = None
+    credentials: str | None = None
+    impersonate_service_account: str | None = None
+    impersonate_service_account_delegations: list[str] | None = None
+    access_token: str | None = None
+    prefix: str | None = None
+    encryption_key: str | None = None
 
     SECRET_FIELDS: ClassVar = ["encryption_key", "access_token"]
 
-    def generate_environment(self) -> Dict:
+    def generate_environment(self) -> dict:
         output = {}
         if self.credentials:
             output["GOOGLE_BACKEND_CREDENTIALS"] = self.credentials
             output["GOOGLE_CREDENTIALS"] = self.credentials
         if self.impersonate_service_account:
-            output[
-                "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT"
-            ] = self.impersonate_service_account
+            output["GOOGLE_IMPERSONATE_SERVICE_ACCOUNT"] = self.impersonate_service_account
         if self.encryption_key:
             output["GOOGLE_ENCRYPTION_KEY"] = self.encryption_key
         return output

--- a/pyterraformer/terraform/backends/local_backend.py
+++ b/pyterraformer/terraform/backends/local_backend.py
@@ -1,18 +1,19 @@
 import atexit
 from dataclasses import dataclass
 from tempfile import TemporaryDirectory
-from typing import Optional, Dict
+from typing import Dict, Optional
+
 from pyterraformer.core.generics import Backend
 from pyterraformer.terraform.backends.base_backend import BaseBackend
 
 
 @dataclass
 class LocalBackend(BaseBackend):
-    path: Optional[str] = None
-    workspace_dir: Optional[str] = None
+    path: str | None = None
+    workspace_dir: str | None = None
 
-    def generate_environment(self) -> Dict:
-        output: Dict = {}
+    def generate_environment(self) -> dict:
+        output: dict = {}
         return output
 
     def as_object(self) -> Backend:

--- a/pyterraformer/terraform/settings.py
+++ b/pyterraformer/terraform/settings.py
@@ -2,5 +2,5 @@ from dataclasses import dataclass
 
 
 @dataclass
-class TerraformConfig(object):
+class TerraformConfig:
     terraform_exec_path: str

--- a/pyterraformer/terraform/terraform.py
+++ b/pyterraformer/terraform/terraform.py
@@ -1,8 +1,9 @@
 import os
 import re
 from dataclasses import dataclass, field
-from subprocess import CalledProcessError, run as sub_run
-from typing import Optional, List, Union
+from subprocess import CalledProcessError
+from subprocess import run as sub_run
+from typing import List, Optional, Union
 
 from pyterraformer.constants import logger
 from pyterraformer.settings import get_default_terraform_location
@@ -11,22 +12,17 @@ from pyterraformer.terraform.backends import BaseBackend, LocalBackend
 
 @dataclass
 class Terraform:
-    terraform_exec_path: Optional[str] = field(
-        default_factory=get_default_terraform_location
-    )
-    plugin_cache_directory: Optional[str] = None
+    terraform_exec_path: str | None = field(default_factory=get_default_terraform_location)
+    plugin_cache_directory: str | None = None
     backend: BaseBackend = field(default_factory=lambda: LocalBackend(path=os.getcwd()))
     workspace: str = "default"
 
-    def run(self, arguments: Union[str, List[str]], path: str):
+    def run(self, arguments: str | list[str], path: str):
         workspace = self._run(["workspace", "show"], path=path).strip()
         logger.info(f"Executing {arguments} in workspace {workspace}.")
         if workspace != self.workspace:
             logger.info(f"swapping to configured workspace {workspace}")
-            workspaces = [
-                v.replace("*", "").strip()
-                for v in self._run(["workspace", "list"], path=path).split("\n")
-            ]
+            workspaces = [v.replace("*", "").strip() for v in self._run(["workspace", "list"], path=path).split("\n")]
             if self.workspace in workspaces:
                 logger.info("workspace found, swapping to")
                 self._run(["workspace", "select", self.workspace], path=path)
@@ -36,7 +32,7 @@ class Terraform:
         self._run(["init"], path=path)
         return self._run(arguments=arguments, path=path)
 
-    def _run(self, arguments: Union[str, List[str]], path: str):
+    def _run(self, arguments: str | list[str], path: str):
         if not self.terraform_exec_path:
             raise ValueError("No terraform executable set, cannot run TF commands.")
         runtime_env = os.environ.copy()
@@ -54,7 +50,7 @@ class Terraform:
         if self.plugin_cache_directory:
             runtime_env["TF_PLUGIN_CACHE_DIR"] = self.plugin_cache_directory
 
-        cmd_array: List[str] = [self.terraform_exec_path, *arguments]
+        cmd_array: list[str] = [self.terraform_exec_path, *arguments]
 
         def run_cmd():
             return sub_run(
@@ -74,7 +70,5 @@ class Terraform:
 
 
 def extract_errors(input: str):
-    found = re.findall(
-        r"(Error:.*)(?:Error:|$)", input, re.IGNORECASE | re.MULTILINE | re.DOTALL
-    )
+    found = re.findall(r"(Error:.*)(?:Error:|$)", input, re.IGNORECASE | re.MULTILINE | re.DOTALL)
     return "\n".join(found).strip()

--- a/pyterraformer/utility/decorators.py
+++ b/pyterraformer/utility/decorators.py
@@ -1,8 +1,8 @@
 from types import MethodType
 
 
-class lazy_property(object):
-    """ used for lazy evaluation of an object attribute. property should represent non-mutable data, as it replaces itself."""
+class lazy_property:
+    """used for lazy evaluation of an object attribute. property should represent non-mutable data, as it replaces itself."""
 
     def __init__(self, fget):
         self.fget = fget
@@ -14,5 +14,5 @@ class lazy_property(object):
         value = self.fget(obj)
         setattr(obj, self.func_name, value)
 
-        setattr(obj, "_method_{}".format(self.func_name), MethodType(self.fget, obj))
+        setattr(obj, f"_method_{self.func_name}", MethodType(self.fget, obj))
         return value

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 codecov
 pytest
 pytest-cov
-flake8
+ruff
+mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 jinja2
 lark
 click
-importlib_metadata; python_version < '3.8'

--- a/scripts/build_all_providers.py
+++ b/scripts/build_all_providers.py
@@ -17,9 +17,7 @@ if __name__ == "__main__":
         version_set = set()
         if provider != "google":
             continue
-        versions = requests.get(
-            f"https://releases.hashicorp.com/terraform-provider-{provider}/"
-        )
+        versions = requests.get(f"https://releases.hashicorp.com/terraform-provider-{provider}/")
         versions_html = BeautifulSoup(versions.text)
         for match in versions_html.body.find_all("a"):
             if "_" in match.text:

--- a/scripts/create_provider_stubs.py
+++ b/scripts/create_provider_stubs.py
@@ -2,11 +2,11 @@
 
 import json
 import os
-from logging import DEBUG
-from logging import StreamHandler
+from logging import DEBUG, StreamHandler
 from pathlib import Path
-from typing import Optional, List, Dict
+from typing import Dict, List, Optional
 
+import click
 from jinja2 import Template
 
 from pyterraformer import HumanSerializer
@@ -14,7 +14,6 @@ from pyterraformer.constants import logger
 from pyterraformer.core import TerraformWorkspace
 from pyterraformer.terraform import Terraform
 from pyterraformer.terraform.backends.local_backend import LocalBackend
-import click
 
 logger.addHandler(StreamHandler())
 logger.setLevel(DEBUG)
@@ -25,19 +24,19 @@ TEMPLATE = Template(
 {%- filter indent(width=indent) %}
 {%- for key, block in blocks.items()  %}
 {%- if block.nesting_mode == 'single' %}
-@dataclass 
+@dataclass
 class {{block.camel_case}}():
     {{ render_blocks(block.blocks, 4) }}
     {%- for item in block.attributes %}{% if not item.optional and not item.computed %}
     {{item.name}}:{{ item.python_type }}{% endif %}{% endfor %}
     # non-optional-blocks
-    
+
     {%- for key, item in block.blocks.items() %}{% if not item.optional and not item.computed %}
     {{item.snake_case}}:{{item.camel_case}}{% endif %}{% endfor %}
-    
+
     {%- for item in block.attributes %}{% if item.optional %}
     {{item.name}}: {{item.python_type}} = EMPTY_DEFAULT{% endif %}{% endfor %}
-    
+
     {%- for key, item  in block.blocks.items() %}{% if item.optional %}
     {{item.snake_case}}: Optional[{{item.camel_case}}]=EMPTY_DEFAULT{% endif %}{% endfor %}
     pass
@@ -45,40 +44,40 @@ class {{block.camel_case}}():
 {%- if block.nesting_mode == 'list' %}
 # wrapper list class
 class {{block.camel_case}}(BlockList):
-    @dataclass 
+    @dataclass
     class {{block.camel_case}}Item():
 {{ render_blocks(block.blocks, 8) }}
         {%- for item in block.attributes %}{% if not item.optional and not item.computed %}
         {{item.name}}:{{ item.python_type }}{% endif %}{% endfor %}
         # non-optional-blocks
-        
+
         {%- for key, item in block.blocks.items() %}{% if not item.optional and not item.computed %}
         {{item.snake_case}}:{{item.camel_case}}{% endif %}{% endfor %}
-        
+
         {%- for item in block.attributes %}{% if item.optional %}
         {{item.name}}: Optional[{{item.python_type}}] = EMPTY_DEFAULT{% endif %}{% endfor %}
-        
+
         {%- for key, item  in block.blocks.items() %}{% if item.optional %}
         {{item.snake_case}}: Optional[{{item.camel_case}}]=EMPTY_DEFAULT{% endif %}{% endfor %}
         pass
     items: List[{{block.camel_case}}Item]
 {% endif %}
-{% if block.nesting_mode == 'set' %}      
+{% if block.nesting_mode == 'set' %}
 # wrapper set class
 class {{block.camel_case}}(BlockSet):
-    @dataclass 
+    @dataclass
     class {{block.camel_case}}Item():
 {{ render_blocks(block.blocks, 8) }}
         {%- for item in block.attributes %}{% if not item.optional and not item.computed %}
         {{item.name}}:{{ item.python_type }}{% endif %}{% endfor %}
         # non-optional-blocks
-        
+
         {%- for key, item in block.blocks.items() %}{% if not item.optional and not item.computed %}
         {{item.snake_case}}:{{item.camel_case}}{% endif %}{% endfor %}
-        
+
         {%- for item in block.attributes %}{% if item.optional %}
         {{item.name}}: Optional[{{item.python_type}}] = EMPTY_DEFAULT{% endif %}{% endfor %}
-        
+
         {%- for key, item  in block.blocks.items() %}{% if item.optional %}
         {{item.snake_case}}: Optional[{{item.camel_case}}]=EMPTY_DEFAULT{% endif %}{% endfor %}
         pass
@@ -98,7 +97,7 @@ from dataclasses import dataclass
 
 
 class {{resource.camel_case}}(ResourceObject):
-    """    
+    """
     Args:
     {%- for item in resource.attributes %}{% if not item.computed and not item.optional %}
         {{item.name}} ({{ item.python_type }}): {% filter indent(width=20) %}{{item.description}}{% endfilter %}{% endif %}{% endfor %}
@@ -106,24 +105,24 @@ class {{resource.camel_case}}(ResourceObject):
         {{item.snake_case}}: Optional[{{item.camel_case}}]{% endif %}{% endfor %}
     """
     _type = '{{resource.snake_case}}'
-    
+
 {{ render_blocks(blocks, 4) }}
-    
+
     def __init__(self,
         tf_id: str,
-        
+
         {%- for item in resource.attributes %}{% if not item.optional and not item.computed %}
         {{item.name}}:{{ item.python_type }},{% endif %}{% endfor %}
         # non-optional-blocks
-        
+
         {%- for key, item  in blocks.items() %}{% if not item.optional and not item.computed %}
         {{item.snake_case}}:{{item.camel_case}},{% endif %}{% endfor %}
         #optional
         _metadata: Optional[ObjectMetadata] = EMPTY_DEFAULT,
-        
+
         {%- for item in resource.attributes %}{% if item.optional %}
         {{item.name}}: {{item.python_type}} = EMPTY_DEFAULT,{% endif %}{% endfor %}
-        
+
         {%- for key, item  in blocks.items() %}{% if item.optional %}
         {{item.snake_case}}: Optional[{{item.camel_case}}]=None,{% endif %}{% endfor %}
         ):
@@ -135,9 +134,9 @@ class {{resource.camel_case}}(ResourceObject):
                 kwargs['{{item.snake_case}}'] = {{ item.snake_case }}
             {% endfor %}
             super().__init__(tf_id=tf_id, _metadata=_metadata, **kwargs)
-            
-        
-        
+
+
+
 
 '''
 )
@@ -163,7 +162,7 @@ def python_type(tf_type: str) -> str:
         type = python_type([v for v in tf_type if v != "set"][0])
         return f"Set[{type}]"
     elif "object" in tf_type:
-        components = python_type([v for v in tf_type if v != "object"][0])
+        python_type([v for v in tf_type if v != "object"][0])
         return "Dict[str,Any]"
     return tf_type
 
@@ -174,8 +173,8 @@ class Attribute:
     type: str
     optional: bool
     computed: bool
-    description: Optional[str] = None
-    default: Optional[str] = None
+    description: str | None = None
+    default: str | None = None
 
     @property
     def python_type(self) -> str:
@@ -187,8 +186,8 @@ class Attribute:
 @dataclass
 class Resource:
     snake_case: str
-    description: Optional[str]
-    attributes: List[Attribute]
+    description: str | None
+    attributes: list[Attribute]
 
     @property
     def camel_case(self):
@@ -208,9 +207,7 @@ class Resource:
             for key, v in info["block"]["attributes"].items()
         ]
         # move optional attributes to the end
-        attributes = sorted(
-            attributes, key=lambda x: "zzz" + x.name if x.optional else x.name
-        )
+        attributes = sorted(attributes, key=lambda x: "zzz" + x.name if x.optional else x.name)
         return Resource(key, description=info.get("description"), attributes=attributes)
 
 
@@ -248,11 +245,11 @@ def generate_blocks(schema: dict, depth=0) -> dict:
 class Block:
     snake_case: str
     optional: bool
-    attributes: List[Attribute]
-    description: Optional[str]
+    attributes: list[Attribute]
+    description: str | None
     nesting_mode: str
     max_items: int = -1
-    blocks: [Optional[Dict[str, "Block"]]] = field(default_factory=dict)
+    blocks: [dict[str, "Block"] | None] = field(default_factory=dict)
 
     def __post_init__(self):
         # all lists can be empty
@@ -269,20 +266,14 @@ class Block:
 def build_resource_class(key: str, schema: dict):
     blocks = generate_blocks(schema)
     # blocks = sorted(blocks, key= lambda x: not x.blocks)
-    class_text = TEMPLATE.render(
-        resource=Resource.parse_from_resource_info(key, schema), blocks=blocks
-    )
+    class_text = TEMPLATE.render(resource=Resource.parse_from_resource_info(key, schema), blocks=blocks)
     return class_text
 
 
 def _create_stubs(provider: str, version: str, output_path: str, terraform_path: str):
     output = {}
-    tf = Terraform(
-        terraform_exec_path=terraform_path, backend=LocalBackend(path=os.getcwd())
-    )
-    workspace = TerraformWorkspace(
-        terraform=tf, path=os.getcwd(), serializer=HumanSerializer(terraform=tf)
-    )
+    tf = Terraform(terraform_exec_path=terraform_path, backend=LocalBackend(path=os.getcwd()))
+    workspace = TerraformWorkspace(terraform=tf, path=os.getcwd(), serializer=HumanSerializer(terraform=tf))
     workspace.add_provider(name="build", source=provider, version=version)
     workspace.save_all()
     tf.run("init", path=os.getcwd())
@@ -302,7 +293,7 @@ def _create_stubs(provider: str, version: str, output_path: str, terraform_path:
 
 def save_stubs(provider: str, version: str, stubs: dict, path: str):
     base_path = Path(path)
-    root = Path(path) / provider / f"v{version.replace('.','_')}"
+    root = Path(path) / provider / f"v{version.replace('.', '_')}"
     os.makedirs(root, exist_ok=True)
     for key, text in stubs.items():
         if not text:
@@ -324,9 +315,7 @@ def save_stubs(provider: str, version: str, stubs: dict, path: str):
 
 
 @click.command()
-@click.option(
-    "--provider", help="The provider name, eg. hashicorp/aws to create stubs for"
-)
+@click.option("--provider", help="The provider name, eg. hashicorp/aws to create stubs for")
 @click.option("--version", help="The version of the provider to create stubs for. ")
 @click.option("--terraform_path", help="The path of the local terraform binary.")
 @click.option("--output_path", help="The output path to put the created files in")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from pytest import fixture
+
 from pyterraformer import HumanSerializer
 
 

--- a/tests/test_human_serializer.py
+++ b/tests/test_human_serializer.py
@@ -10,16 +10,16 @@ def test_human_serialization():
     hs = HumanSerializer()
     example_string = """resource "aws_s3_bucket" "b" {
       bucket = "my-tf-test-bucket"
-    
+
       tags = {
         Name        = "My bucket"
         Environment = "Dev"
       }
     }
-    
+
     resource "aws_s3_bucket" "b2" {
       bucket = "my-tf-test-bucket"
-    
+
       tags = {
         Name        = "My bucket"
         Environment = "Dev"
@@ -32,7 +32,7 @@ def test_human_serialization():
 
     test_string = """resource "aws_s3_bucket" "b" {
       bucket = "my-updated-bucket"
-    
+
       tags = {
         Name        = "My bucket"
         Environment = "Prod"
@@ -45,7 +45,6 @@ def test_human_serialization():
 
 
 def test_block_parsing(human_serializer):
-
     split = """terraform {
   backend "local" {
 
@@ -91,7 +90,6 @@ def test_block_parsing(human_serializer):
 
 
 def test_block_parsing_variants(human_serializer):
-
     split = """terraform {
   backend "local" {
 
@@ -136,7 +134,6 @@ def test_block_parsing_variants(human_serializer):
 
 
 def test_comments(human_serializer):
-
     split = """resource "google_container_cluster" "primary" {
   name     = "my-gke-cluster"
   location = "us-central1"
@@ -187,6 +184,4 @@ MULTILINE
     rendered = human_serializer.render_object(resource)
     assert "# maintain position" in rendered
     assert "# this is a helpful comment" in rendered
-    assert rendered.find("# maintain position") < rendered.find(
-        "# this is a helpful comment"
-    )
+    assert rendered.find("# maintain position") < rendered.find("# this is a helpful comment")

--- a/tests/test_parsing/test_parsing_cases.py
+++ b/tests/test_parsing/test_parsing_cases.py
@@ -1,7 +1,6 @@
-from pathlib import Path
 import os
-from logging import DEBUG
-from logging import StreamHandler
+from logging import DEBUG, StreamHandler
+from pathlib import Path
 
 from pyterraformer import HumanSerializer
 from pyterraformer.constants import logger
@@ -16,9 +15,7 @@ logger.setLevel(DEBUG)
 def test_all_parsing():
     test_cases = Path(__file__).parent / "cases"
     tf = Terraform(terraform_exec_path=None, backend=LocalBackend(path=test_cases))
-    workspace = TerraformWorkspace(
-        terraform=tf, path=test_cases, serializer=HumanSerializer(terraform=tf)
-    )
+    workspace = TerraformWorkspace(terraform=tf, path=test_cases, serializer=HumanSerializer(terraform=tf))
 
     all_files = os.listdir(test_cases)
     for file in all_files:

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,5 +1,6 @@
-from pyterraformer.exceptions import TerraformExecutionError
 import pytest
+
+from pyterraformer.exceptions import TerraformExecutionError
 
 
 def test_readme():
@@ -9,7 +10,7 @@ def test_readme():
 
     example_string: str = """resource "aws_s3_bucket" "b" {
       bucket = "my-tf-test-bucket"
-      
+
       tags = {
     Name        = "My bucket"
         Environment = "Dev"
@@ -29,4 +30,4 @@ def test_readme():
     # and write the modified namespace back
     # formatting requires a valid terraform binary to be provided
     with pytest.raises(TerraformExecutionError):
-        updated = hs.render_object(bucket, format=True)
+        hs.render_object(bucket, format=True)


### PR DESCRIPTION
# Update Python version support to 3.10-3.14 and modernize linting

## Summary

- Drop support for Python 3.7, 3.8, and 3.9; add support for Python 3.12, 3.13, and 3.14
- Replace flake8 with ruff for faster, more comprehensive linting
- Add mypy for static type checking in CI

## Changes

### Python Version Updates
- **pyproject.toml**: Update `requires-python` from `>=3.7` to `>=3.10` and update classifiers
- **pythonpackage.yml**: Update CI matrix to test Python 3.10, 3.11, 3.12, 3.13, and 3.14
- **requirements.txt**: Remove `importlib_metadata` backport dependency (no longer needed for Python 3.10+)
- **pyterraformer/__init__.py**: Simplify imports since `importlib.metadata` is always available

### Linting Modernization
- **requirements-test.txt**: Replace `flake8` with `ruff` and `mypy`
- **.flake8**: Deleted (configuration moved to pyproject.toml)
- **pyproject.toml**: Add ruff and mypy configuration with equivalent rules to the old flake8 setup
- **pythonpackage.yml**: Update CI to run `ruff check`, `ruff format --check`, and `mypy`

## Test plan

- [ ] CI passes on all Python versions (3.10-3.14)
- [ ] Ruff linting passes
- [ ] Ruff format check passes
- [ ] Mypy type checking passes
- [ ] All existing tests pass