### PR TITLE
refactor: modernize codebase with future annotations and remove dead code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,16 +98,11 @@ ignore = [
     "E501",   # line too long (handled by formatter)
     "S101",   # assert used (acceptable in tests)
     "S603",   # subprocess call - false positive for trusted input
-    "F401",   # unused imports (in __init__.py files)
     "F811",   # redefinition of unused name
     "C901",   # too complex
     "UP035",  # deprecated typing imports (Dict, List, etc.) - keep for compatibility
     "B904",   # raise from in except clause - not critical
     "E402",   # module level import not at top of file - needed for template strings
-    "SIM101", # multiple isinstance calls - keep for readability
-    "SIM108", # ternary operator - keep if-else for readability
-    "SIM114", # combine if branches - keep for readability
-    "SIM118", # key in dict.keys() - keep for clarity
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,14 +95,8 @@ select = [
     "S",    # flake8-bandit (security)
 ]
 ignore = [
-    "E501",   # line too long (handled by formatter)
-    "S101",   # assert used (acceptable in tests)
-    "S603",   # subprocess call - false positive for trusted input
-    "F811",   # redefinition of unused name
-    "C901",   # too complex
-    "UP035",  # deprecated typing imports (Dict, List, etc.) - keep for compatibility
-    "B904",   # raise from in except clause - not critical
-    "E402",   # module level import not at top of file - needed for template strings
+    "E501",  # line too long (handled by formatter)
+    "S101",  # assert used (acceptable in tests)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,13 +94,12 @@ select = [
     "SIM",  # flake8-simplify
     "S",    # flake8-bandit (security)
 ]
-ignore = [
-    "E501",  # line too long (handled by formatter)
-    "S101",  # assert used (acceptable in tests)
-]
+ignore = []
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+"tests/**/*.py" = ["S101"]  # assert is standard in pytest
+"pyterraformer/serializer/human_resources/engine.py" = ["E501"]  # grammar strings can't be reformatted
 
 [tool.ruff.lint.isort]
 known-first-party = ["pyterraformer"]

--- a/pyterraformer/config.py
+++ b/pyterraformer/config.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 from pyterraformer.settings import get_default_terraform_location
 

--- a/pyterraformer/config.py
+++ b/pyterraformer/config.py
@@ -2,10 +2,6 @@ from dataclasses import dataclass
 
 from pyterraformer.settings import get_default_terraform_location
 
-# tempdir = mkdtemp()
-#
-# atexit.register(shutil.rmtree, tempdir)
-
 
 @dataclass
 class TerraformerConfig:
@@ -14,10 +10,6 @@ class TerraformerConfig:
     tf_plugin_cache_dir: str | None = None
     default_variable_file: str = "variables.tf"
     default_data_file: str = "data.tf"
-
-    #
-    # def configure_git_module_provider(self):
-    #     pass
 
     @property
     def state_provider(self):

--- a/pyterraformer/core/generics/backend.py
+++ b/pyterraformer/core/generics/backend.py
@@ -1,17 +1,7 @@
 from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
-# from pyterraformer.core.resources import
-
 
 class Backend(TerraformObject):
     def __init__(self, name: str, _metadata: ObjectMetadata | None = None, **kwargs):
         TerraformObject.__init__(self, "backend", _metadata=_metadata, **kwargs)
         self.name = str(name).replace('"', "")
-
-    # def render(self, variables=None):
-    #     final = {}
-    #     for key in sorted(self.render_variables.keys()):
-    #         if key != "name":
-    #             final[key] = self.render_variables[key]
-    #     final = process_attribute(final)
-    #     return self.template.render(name=self.name, render_attributes=final)

--- a/pyterraformer/core/generics/backend.py
+++ b/pyterraformer/core/generics/backend.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 # from pyterraformer.core.resources import

--- a/pyterraformer/core/generics/comment.py
+++ b/pyterraformer/core/generics/comment.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 
@@ -11,10 +9,7 @@ class Comment(TerraformObject):
         _metadata: ObjectMetadata | None = None,
     ):
         self.multiline = multiline
-        if self.multiline:
-            text = f"/*{text}*/"
-        else:
-            text = text.strip()
+        text = f"/*{text}*/" if self.multiline else text.strip()
         TerraformObject.__init__(self, "comment", tf_id=None, text=text, _metadata=_metadata)
 
     @property

--- a/pyterraformer/core/generics/data.py
+++ b/pyterraformer/core/generics/data.py
@@ -13,25 +13,3 @@ class Data(TerraformObject):
         return (
             f"{self._type}({self.name})(" + ", ".join([f'{key}="{val}"' for key, val in self.render_variables.items()]) + ")"
         )
-
-    #
-    # def render(self, variables=None):
-    #     variables = variables or {}
-    #     final = {}
-    #     for key in sorted(self.render_variables.keys()):
-    #         if key not in final and key != "type":
-    #             final[key] = self.render_variables[key]
-    #
-    #     for key, item in final.items():
-    #         if (
-    #             isinstance(item, str)
-    #             and item.startswith('"${')
-    #             and item.endswith('$}"')
-    #         ):
-    #             item = item[3:-3]
-    #             final[key] = Literal(item)
-    #
-    #     output = process_attribute(final)
-    #     return self.template.render(
-    #         name=self.name, type=self.type, render_attributes=output, **variables
-    #     )

--- a/pyterraformer/core/generics/interpolation.py
+++ b/pyterraformer/core/generics/interpolation.py
@@ -18,6 +18,8 @@ StringLit
             PropertyLookup -> Resolve Left to Right
 """
 
+from __future__ import annotations
+
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -59,7 +61,7 @@ def variable_helper(arg, workspace, file, parent, parent_instance):
 
 
 class FileLookupInstantiator(Resolvable):
-    def __init__(self, workspace: "TerraformWorkspace"):
+    def __init__(self, workspace: TerraformWorkspace):
         for _key, file in workspace.files.items():
             for object in file.objects:
                 if hasattr(object, "tf_id"):
@@ -69,7 +71,7 @@ class FileLookupInstantiator(Resolvable):
 
 
 class FileObjectLookupInstantiator(Resolvable):
-    def __init__(self, workspace: "TerraformWorkspace"):
+    def __init__(self, workspace: TerraformWorkspace):
         # TODO: 2022-06-05 figure out how to do this bette
         from pyterraformer.core.namespace import LazyFile
 
@@ -102,7 +104,7 @@ class FileObjectSubClassLookupInstantiator(Resolvable):
 
 
 class DataLookupInstantiator(Resolvable):
-    def __init__(self, workspace: "TerraformWorkspace"):
+    def __init__(self, workspace: TerraformWorkspace):
         self.workspace = workspace
 
     def __getattr__(self, item):
@@ -120,13 +122,13 @@ class DataSubClassLookupInstantiator(Resolvable):
 
 
 class VariableLookupInstantiator(Resolvable):
-    def __init__(self, workspace: "TerraformWorkspace"):
+    def __init__(self, workspace: TerraformWorkspace):
         for key, value in workspace.variables.items():
             setattr(self, key, value)
 
 
 class TerraformLookupInstantiator(Resolvable):
-    def __init__(self, workspace: "TerraformWorkspace"):
+    def __init__(self, workspace: TerraformWorkspace):
         if workspace.terraform:
             self.workspace = workspace.terraform.workspace
         else:
@@ -134,7 +136,7 @@ class TerraformLookupInstantiator(Resolvable):
 
 
 class LocalLookupInstantiator(Resolvable):
-    def __init__(self, file: "TerraformFile"):
+    def __init__(self, file: TerraformFile):
         for key, value in file.locals.items():
             setattr(self, key, value)
 
@@ -228,8 +230,8 @@ class PropertyLookup(Resolvable):
 
     def resolve(
         self,
-        workspace: "TerraformWorkspace",
-        file: "TerraformFile",
+        workspace: TerraformWorkspace,
+        file: TerraformFile,
         parent: Resolvable | None = None,
         parent_instance: Resolvable | None = None,
     ):

--- a/pyterraformer/core/generics/interpolation.py
+++ b/pyterraformer/core/generics/interpolation.py
@@ -72,7 +72,6 @@ class FileLookupInstantiator(Resolvable):
 
 class FileObjectLookupInstantiator(Resolvable):
     def __init__(self, workspace: TerraformWorkspace):
-        # TODO: 2022-06-05 figure out how to do this bette
         from pyterraformer.core.namespace import LazyFile
 
         self.workspace = workspace
@@ -176,7 +175,6 @@ class Interpolation(Resolvable):
 class DictLookup(Resolvable):
     def __init__(self, base, lookup):
         self.base = base
-        # TODO don't return a list here
         self.contents = lookup
         # the lookup will be a nested list
         self.lookup = lookup[0]
@@ -199,7 +197,6 @@ class DictLookup(Resolvable):
 class ArrayLookup(Resolvable):
     def __init__(self, base, lookup):
         self.base = base
-        # TODO don't return a list here
         self.contents = lookup
         # the lookup will be a nested list
         self.lookup = lookup[0]
@@ -375,15 +372,6 @@ class Types(Resolvable):
         return "types({})".format(",".join([item.__repr__() for item in self.items]))
 
     def resolve(self, workspace, file, parent=None, parent_instance=None):
-        # final = []
-        # for item in self.items:
-        #     if isinstance(parent_instance, PropertyLookup):
-        #         resolved = PropertyLookup(item).resolve(workspace, file, parent, parent_instance)
-        #         out = resolved
-        #     else:
-        #         out = item
-        #     final.append(out)
-        # concat = ",".join(final)
         return "types({})".format(",".join([item.__repr__() for item in self.items]))
 
 
@@ -473,7 +461,6 @@ class Parenthetical(Resolvable):
         return "({})".format("".join([val.__repr__() for val in self.contents]))
 
     def resolve(self, workspace, file, parent=None, parent_instance=None):
-        # parent = None
         parent_instance = self
         resolve = deepcopy(self.contents)
         while resolve:
@@ -628,7 +615,6 @@ class LegacySplat(Resolvable):
         return "{}".format(*[val.__repr__() for val in self.contents[:1]])
 
     def resolve(self, workspace, file, parent=None, parent_instance=None):
-        # parent = None
         parent_instance = self
         resolve = deepcopy(self.contents)
         while resolve:

--- a/pyterraformer/core/generics/interpolation.py
+++ b/pyterraformer/core/generics/interpolation.py
@@ -20,7 +20,7 @@ StringLit
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pyterraformer.core.namespace import TerraformFile

--- a/pyterraformer/core/generics/local.py
+++ b/pyterraformer/core/generics/local.py
@@ -1,4 +1,4 @@
-from pyterraformer.core.objects import TerraformObject  # , process_attribute
+from pyterraformer.core.objects import TerraformObject
 
 
 class Local(TerraformObject):
@@ -8,12 +8,3 @@ class Local(TerraformObject):
             pass_on.append([key, value])
 
         TerraformObject.__init__(self, _type="local", original_text=text, attributes=pass_on)
-
-    # def render(self, variables=None):
-    #     from analytics_terraformer_core.utility import clean_render_dictionary
-    #
-    #     variables = variables or {}
-    #
-    #     final = clean_render_dictionary(self.render_variables, [])
-    #     output = process_attribute(final)
-    #     return self.template.render(render_attributes=output, **variables)

--- a/pyterraformer/core/generics/meta_arguments.py
+++ b/pyterraformer/core/generics/meta_arguments.py
@@ -1,6 +1,5 @@
 # from analytics_utility_core.decorators import lazy_property
 
-from typing import Optional
 
 from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 

--- a/pyterraformer/core/generics/meta_arguments.py
+++ b/pyterraformer/core/generics/meta_arguments.py
@@ -1,6 +1,3 @@
-# from analytics_utility_core.decorators import lazy_property
-
-
 from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 
@@ -13,16 +10,6 @@ class Provider(TerraformObject):
         return (
             f"{self._type}-{self.ptype}(" + ", ".join([f'{key}="{val}"' for key, val in self.render_variables.items()]) + ")"
         )
-
-    # def render(self, variables=None):
-    #     # from analytics_terraformer_core.utility import clean_render_dictionary
-    #
-    #     variables = variables or {}
-    #     variables["type"] = self.ptype
-    #
-    #     # final = clean_render_dictionary(self.render_variables, [])
-    #     output = process_attribute(self.render_variables)
-    #     return self.template.render(render_attributes=output, **variables)
 
 
 class Lifecycle(TerraformObject):

--- a/pyterraformer/core/generics/terraform.py
+++ b/pyterraformer/core/generics/terraform.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 

--- a/pyterraformer/core/generics/terraform.py
+++ b/pyterraformer/core/generics/terraform.py
@@ -3,15 +3,4 @@ from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 class TerraformConfig(TerraformObject):
     def __init__(self, _metadata: ObjectMetadata | None = None, **kwargs):
-        # self.backends = [obj for obj in attributes if isinstance(obj, Backend)]
         TerraformObject.__init__(self, "terraform", _metadata=_metadata, **kwargs)
-
-    # def render(self, variables=None):
-    #     from pyterraformer.core.generics import Block, Literal
-    #
-    #     output = {
-    #         "required_version": self.required_version,
-    #         "backend": Block([Literal(backend.render()) for backend in self.backends]),
-    #     }
-    #     final = process_attribute(output)
-    #     return self.template.render(render_attributes=final)

--- a/pyterraformer/core/generics/variables.py
+++ b/pyterraformer/core/generics/variables.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from pyterraformer.core.objects import TerraformObject
@@ -24,17 +26,17 @@ class Variable(TerraformObject):
                 return item
         raise KeyError(val)
 
-    def render_lookup(self, item) -> "Literal":
+    def render_lookup(self, item) -> Literal:
         from pyterraformer.core.generics import Literal
 
         return Literal(f'var.{self.name}["{item}"]')
 
-    def render_attribute(self, item) -> "Literal":
+    def render_attribute(self, item) -> Literal:
         from pyterraformer.core.generics import Literal
 
         return Literal(f"var.{self.name}.{item}")
 
-    def render_basic(self) -> "Literal":
+    def render_basic(self) -> Literal:
         from pyterraformer.core.generics import Literal
 
         return Literal(f"var.{self.name}")
@@ -45,7 +47,7 @@ class Variable(TerraformObject):
                 return item
         return fallback
 
-    def get_type(self, val) -> "Literal":
+    def get_type(self, val) -> Literal:
         from pyterraformer.core.generics import Literal, StringLit
         from pyterraformer.core.generics.interpolation import String
 

--- a/pyterraformer/core/generics/variables.py
+++ b/pyterraformer/core/generics/variables.py
@@ -63,13 +63,11 @@ class Variable(TerraformObject):
             return Literal("map(any)")
         elif isinstance(val, set):
             return Literal(f"set({self.get_type(next(iter(val))).value})")
-        elif isinstance(val, str):
-            return Literal("string")
-        elif isinstance(val, StringLit):
+        elif isinstance(val, (str, StringLit)):
             return Literal("string")
         elif isinstance(val, bool):
             return Literal("bool")
-        elif isinstance(val, int) or isinstance(val, float):
+        elif isinstance(val, (int, float)):
             return Literal("number")
         elif isinstance(val, String):
             return Literal("string")

--- a/pyterraformer/core/modules.py
+++ b/pyterraformer/core/modules.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
 

--- a/pyterraformer/core/namespace.py
+++ b/pyterraformer/core/namespace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -15,8 +17,8 @@ class TerraformNamespace:
     def __init__(
         self,
         name: str,
-        workspace: "TerraformWorkspace",
-        objects: list["TerraformObject"] | None = None,
+        workspace: TerraformWorkspace,
+        objects: list[TerraformObject] | None = None,
     ):
         self.workspace: TerraformWorkspace = workspace
         self.name = name
@@ -29,11 +31,11 @@ class TerraformNamespace:
 
 
 class LazyFile(TerraformNamespace):
-    def __init__(self, file: str | Path, workspace: "TerraformWorkspace"):
+    def __init__(self, file: str | Path, workspace: TerraformWorkspace):
         super().__init__(name=os.path.basename(file).replace(".tf", ""), workspace=workspace)
         self.file = file
 
-    def resolve(self) -> "TerraformFile":
+    def resolve(self) -> TerraformFile:
         if not self.workspace.serializer:
             raise ValueError("No parser provided to look at files in this workspace")
         return self.workspace.serializer.parse_file(self.file, workspace=self.workspace)
@@ -42,10 +44,10 @@ class LazyFile(TerraformNamespace):
 class TerraformFile(TerraformNamespace):
     def __init__(
         self,
-        workspace: "TerraformWorkspace",
+        workspace: TerraformWorkspace,
         text: str,
         location: str | Path,
-        objects: list["TerraformObject"] | None = None,
+        objects: list[TerraformObject] | None = None,
     ):
         self._text = text
         name = os.path.basename(location)
@@ -106,7 +108,7 @@ class TerraformFile(TerraformNamespace):
 
     def add_object(
         self,
-        object: "TerraformObject",
+        object: TerraformObject,
         position: InsertPosition | int = InsertPosition.DEFAULT,
         exists_okay: bool = False,
         replace: bool = False,
@@ -164,4 +166,4 @@ class TerraformFile(TerraformNamespace):
 
         except IndexError:
             self._idx = 0
-            raise StopIteration  # Done iterating.
+            raise StopIteration from None  # Done iterating.

--- a/pyterraformer/core/namespace.py
+++ b/pyterraformer/core/namespace.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING
 
 from pyterraformer.core.utility import value_match
 from pyterraformer.enums import InsertPosition

--- a/pyterraformer/core/namespace.py
+++ b/pyterraformer/core/namespace.py
@@ -117,12 +117,14 @@ class TerraformFile(TerraformNamespace):
         duplicates = self._detect_duplicates(object)
         if duplicates:
             if replace:
-                self.objects = [obj for idx, obj in enumerate(self.objects) if idx not in (duplicates)]
+                self.objects = [obj for idx, obj in enumerate(self.objects) if idx not in duplicates]
             elif exists_okay:
                 return
             else:
+                duplicate_objs = [obj for idx, obj in enumerate(self.objects) if idx in duplicates]
                 raise ValueError(
-                    f"Duplicate resource name or ID detected {[obj for idx, obj in enumerate(self.objects) if idx in (duplicates)]} in file {self.name}! Cannot add unless the 'replace' or 'exists_okay' flags are set."
+                    f"Duplicate resource name or ID detected {duplicate_objs} in file {self.name}! "
+                    f"Cannot add unless the 'replace' or 'exists_okay' flags are set."
                 )
 
         if position == InsertPosition.FIRST:

--- a/pyterraformer/core/objects.py
+++ b/pyterraformer/core/objects.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/pyterraformer/core/objects.py
+++ b/pyterraformer/core/objects.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Optional
-
-from pyterraformer.exceptions import ValidationError
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pyterraformer.core.namespace import TerraformNamespace
@@ -101,9 +99,7 @@ class TerraformObject:
 
         if isinstance(item, list):
             resolved = [self.resolve_item(sub_item) for sub_item in item]
-        elif isinstance(item, str):
-            resolved = item
-        elif isinstance(item, int):
+        elif isinstance(item, (str, int)):
             resolved = item
         elif isinstance(item, dict):
             resolved = {self.resolve_item(key): self.resolve_item(value) for key, value in item.items()}

--- a/pyterraformer/core/objects.py
+++ b/pyterraformer/core/objects.py
@@ -28,14 +28,6 @@ class TerraformObject:
         self.tf_id = tf_id
         arguments = kwargs or {}
         self.render_variables: dict[str, str] = {str(key): value for key, value in arguments.items()}
-        # for attribute in self.attributes:
-        #     if isinstance(attribute, list):
-        #         # always cast keys to string
-        #         self.render_variables[str(attribute[0])] = attribute[1]
-        #     elif isinstance(attribute, Block):
-        #         base = self.render_variables.get(attribute.name, Block())
-        #         base.append(attribute)
-        #         self.render_variables[attribute.name] = base
         self._type: str = _type
         self._changed: bool = False
         self._workspace = None

--- a/pyterraformer/core/resources/resource_object.py
+++ b/pyterraformer/core/resources/resource_object.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List, Optional
 
 from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 

--- a/pyterraformer/core/utility.py
+++ b/pyterraformer/core/utility.py
@@ -2,7 +2,6 @@ import os
 from collections.abc import Iterator
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import List, Union
 
 
 def splitall(path: str) -> Iterator[str]:

--- a/pyterraformer/core/workspace.py
+++ b/pyterraformer/core/workspace.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import re
 from collections import defaultdict
 from fnmatch import fnmatch
 from os.path import dirname
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from pyterraformer.constants import logger
 from pyterraformer.core.generics import BlockList, Literal
@@ -90,8 +92,8 @@ class TerraformWorkspace:
         path: str | PurePath,
         terraform: Terraform | None = None,
         serializer: BaseSerializer | None = None,
-        files: list["TerraformFile"] | None = None,
-        children: list["TerraformWorkspace"] | None = None,
+        files: list[TerraformFile] | None = None,
+        children: list[TerraformWorkspace] | None = None,
     ):
         self.terraform = terraform
         self.path = str(path)
@@ -116,7 +118,7 @@ class TerraformWorkspace:
     def relative_path(self, path: str):
         return get_root(str(self._path), path)
 
-    def get_file_safe(self, name: str) -> "TerraformFile":
+    def get_file_safe(self, name: str) -> TerraformFile:
         from pyterraformer.core.namespace import TerraformFile
 
         out = self.files.get(name)
@@ -153,7 +155,7 @@ class TerraformWorkspace:
         required_providers[0][name] = {"source": source, **kwargs}
         existing.required_providers = required_providers
 
-    def add_file(self, file: Union["TerraformFile", PurePath, str]) -> "TerraformFile":
+    def add_file(self, file: TerraformFile | PurePath | str) -> TerraformFile:
         from pyterraformer.core.namespace import TerraformFile
 
         if isinstance(file, TerraformFile):

--- a/pyterraformer/core/workspace.py
+++ b/pyterraformer/core/workspace.py
@@ -21,17 +21,12 @@ if TYPE_CHECKING:
 def process_attribute(input: Any, level=0):
     from pyterraformer.core.generics import Variable
 
-    # if isinstance(input, Block):
-    #     input = {input.name: input._keys}
-
     if not isinstance(input, dict):
         return input
     output: dict[str, Any] = {}
     for key, item in input.items():
         if isinstance(item, Variable):
             output[key] = item.render_basic()
-        # elif isinstance(item, StringLit):
-        #     output[key] = item.__repr__()
         elif isinstance(item, Literal):
             output[key] = item
         elif isinstance(item, BlockList):

--- a/pyterraformer/core/workspace.py
+++ b/pyterraformer/core/workspace.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from fnmatch import fnmatch
 from os.path import dirname
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from pyterraformer.constants import logger
 from pyterraformer.core.generics import BlockList, Literal

--- a/pyterraformer/serializer/base_serializer.py
+++ b/pyterraformer/serializer/base_serializer.py
@@ -1,12 +1,10 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pyterraformer.core import (
-        TerraformNamespace,
-        TerraformObject,
-        TerraformWorkspace,
-    )
+    from pyterraformer.core import TerraformNamespace, TerraformObject, TerraformWorkspace
 
 
 class BaseSerializer:
@@ -19,19 +17,17 @@ class BaseSerializer:
     def parse_string(self, string: str):
         raise NotImplementedError
 
-    def parse_file(self, path: str | Path, workspace: "TerraformWorkspace"):
+    def parse_file(self, path: str | Path, workspace: TerraformWorkspace):
         raise NotImplementedError
 
     def _format_string(self, string: str):
         raise NotImplementedError
 
-    def render_object(self, object: "TerraformObject", format: bool | None = None) -> str:
+    def render_object(self, object: TerraformObject, format: bool | None = None) -> str:
         raise NotImplementedError
 
-    def render_namespace(self, namespace: "TerraformNamespace", format: bool | None = None) -> str:
+    def render_namespace(self, namespace: TerraformNamespace, format: bool | None = None) -> str:
         raise NotImplementedError
 
-    def render_workspace(self, workspace: "TerraformWorkspace") -> dict[str, str]:
+    def render_workspace(self, workspace: TerraformWorkspace) -> dict[str, str]:
         raise NotImplementedError
-
-    #

--- a/pyterraformer/serializer/base_serializer.py
+++ b/pyterraformer/serializer/base_serializer.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pyterraformer.core import (

--- a/pyterraformer/serializer/human_resources/engine.py
+++ b/pyterraformer/serializer/human_resources/engine.py
@@ -1,5 +1,5 @@
 import builtins
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from lark import Lark, Transformer, v_args
 from lark.tree import Meta

--- a/pyterraformer/serializer/human_resources/engine.py
+++ b/pyterraformer/serializer/human_resources/engine.py
@@ -39,8 +39,6 @@ from pyterraformer.core.generics import (
 from pyterraformer.core.modules import ModuleObject
 from pyterraformer.core.objects import ObjectMetadata, TerraformObject
 
-# TODO: rewrite to comply with https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/spec.md
-
 RESOURCES_MAP: dict = {}
 
 grammar = r"""
@@ -266,9 +264,6 @@ class ParseToObjects(Transformer):
         _type = str(_type).replace('"', "")
         object_type = RESOURCES_MAP.get(_type, ResourceObject)
         object_type._type = _type
-        # out = RESOURCES_MAP[str(type).replace('"', "")](
-        #     name, str(type), , args[2:]
-        # )
         remaining = args[2:]
         parsed = args_to_dict(remaining)
         return object_type(tf_id=name, _metadata=metadata, **parsed)

--- a/pyterraformer/serializer/human_resources/module.py
+++ b/pyterraformer/serializer/human_resources/module.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pyterraformer.core.generics import Literal
 from pyterraformer.core.objects import TerraformObject
 

--- a/pyterraformer/serializer/human_resources/module.py
+++ b/pyterraformer/serializer/human_resources/module.py
@@ -31,8 +31,6 @@ class BaseModule(TerraformObject):
     def version(self):
         if self.filterered_source.startswith("http"):
             return extract_http_version(self.filterered_source)
-        # elif self.filtered_source.startswith('git'):
-        #     return extract_http_version(self.filterered_source)
         else:
             raise ValueError(f"Unable to parse version from source {self.source}")
 

--- a/pyterraformer/serializer/human_serializer.py
+++ b/pyterraformer/serializer/human_serializer.py
@@ -3,7 +3,7 @@ from os.path import dirname, join
 from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import jinja2
 
@@ -17,7 +17,6 @@ from pyterraformer.serializer.human_resources.engine import parse_text
 
 if TYPE_CHECKING:
     from pyterraformer.core import (
-        TerraformFile,
         TerraformNamespace,
         TerraformObject,
         TerraformWorkspace,
@@ -39,10 +38,7 @@ def process_attribute(input: Any):
     if not valid:
         return input
 
-    if is_dataclass(input) and not isinstance(input, type):
-        final_input = asdict(input)
-    else:
-        final_input = input
+    final_input = asdict(input) if is_dataclass(input) and not isinstance(input, type) else input
     output: dict[str, Any] = {}
     for key, item in final_input.items():
         if item == EMPTY_DEFAULT:
@@ -78,10 +74,6 @@ class HumanSerializer(BaseSerializer):
             self.terraform = terraform
         elif terraform:
             self.terraform = Terraform(terraform_exec_path=terraform)
-
-    #
-    # def _format_path(self):
-    #     self.terraform.
 
     @property
     def can_format(self) -> bool:
@@ -127,7 +119,7 @@ class HumanSerializer(BaseSerializer):
         variables["tf_id"] = object.tf_id
         variables["type"] = object._type
         final = {}
-        for key in object.render_variables.keys():
+        for key in object.render_variables:
             if key not in final:
                 final[key] = object.render_variables[key]
         if isinstance(object, TerraformConfig):
@@ -139,9 +131,6 @@ class HumanSerializer(BaseSerializer):
         else:
             template_name = "generic.tf"
         template = env.get_template(template_name)
-        # print(final)
-        # print(process_attribute(final))
-        # raise ValueError
         string = template.render(render_attributes=process_attribute(final), **variables)
 
         if format:

--- a/pyterraformer/serializer/human_serializer.py
+++ b/pyterraformer/serializer/human_serializer.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from dataclasses import asdict, is_dataclass
 from os.path import dirname, join
 from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 import jinja2
 
@@ -16,11 +18,7 @@ from pyterraformer.serializer.base_serializer import BaseSerializer
 from pyterraformer.serializer.human_resources.engine import parse_text
 
 if TYPE_CHECKING:
-    from pyterraformer.core import (
-        TerraformNamespace,
-        TerraformObject,
-        TerraformWorkspace,
-    )
+    from pyterraformer.core import TerraformNamespace, TerraformObject, TerraformWorkspace
     from pyterraformer.terraform import Terraform
 
 TEMPLATE_PATH = join(dirname(__file__), "templates")
@@ -66,7 +64,7 @@ def process_attribute(input: Any):
 
 
 class HumanSerializer(BaseSerializer):
-    def __init__(self, terraform: Union[str, "Terraform"] | None = None):
+    def __init__(self, terraform: str | Terraform | None = None):
         from pyterraformer.terraform import Terraform
 
         self.terraform: Terraform | None = None
@@ -82,7 +80,7 @@ class HumanSerializer(BaseSerializer):
     def parse_string(self, string: str):
         return parse_text(string)
 
-    def parse_file(self, path: str | Path, workspace: "TerraformWorkspace"):
+    def parse_file(self, path: str | Path, workspace: TerraformWorkspace):
         from pyterraformer.core.namespace import TerraformFile
 
         with open(path) as f:
@@ -103,13 +101,13 @@ class HumanSerializer(BaseSerializer):
                 logger.error(str(e))
                 raise TerraformExecutionError(
                     f"File not found - is the terraform executable path set correctly and accessible to this user? Error: {str(e)}"
-                )
+                ) from e
             except CalledProcessError as e:
                 logger.error(f"Unable to format file \n{string}")
                 raise e
             return file_name.open().read()
 
-    def render_object(self, object: "TerraformObject", format: bool | None = None) -> str:
+    def render_object(self, object: TerraformObject, format: bool | None = None) -> str:
         if format and not self.can_format:
             raise ValueError("No terraform executable configured, cannot format.")
         from pyterraformer.core.generics import TerraformConfig
@@ -137,7 +135,7 @@ class HumanSerializer(BaseSerializer):
             string = self._format_string(string)
         return string
 
-    def render_namespace(self, namespace: "TerraformNamespace", format: bool | None = None) -> str:
+    def render_namespace(self, namespace: TerraformNamespace, format: bool | None = None) -> str:
         from pyterraformer.core.generics import Comment
 
         format = format if format is not None else self.can_format
@@ -158,7 +156,7 @@ class HumanSerializer(BaseSerializer):
             return self._format_string(string)
         return "".join(out)
 
-    def render_workspace(self, workspace: "TerraformWorkspace", format: bool | None = None) -> dict[str, str]:
+    def render_workspace(self, workspace: TerraformWorkspace, format: bool | None = None) -> dict[str, str]:
         format = format if format is not None else self.can_format
         output = {}
         for name, file in workspace.files.items():

--- a/pyterraformer/serializer/human_serializer.py
+++ b/pyterraformer/serializer/human_serializer.py
@@ -100,7 +100,7 @@ class HumanSerializer(BaseSerializer):
             except FileNotFoundError as e:
                 logger.error(str(e))
                 raise TerraformExecutionError(
-                    f"File not found - is the terraform executable path set correctly and accessible to this user? Error: {str(e)}"
+                    f"File not found - is the terraform executable path set correctly and accessible to this user? Error: {e}"
                 ) from e
             except CalledProcessError as e:
                 logger.error(f"Unable to format file \n{string}")

--- a/pyterraformer/settings.py
+++ b/pyterraformer/settings.py
@@ -12,7 +12,7 @@ def get_default_terraform_location() -> str | None:
     cmd = ["where", "terraform"] if system() == "Windows" else ["which", "terraform"]
 
     try:
-        output = run(cmd, check=True, capture_output=True, encoding="utf-8")
+        output = run(cmd, check=True, capture_output=True, encoding="utf-8")  # noqa: S603
         if output.stdout:
             # where may return multiple lines
             output_str = output.stdout.split("\n")[0].strip()

--- a/pyterraformer/settings.py
+++ b/pyterraformer/settings.py
@@ -1,5 +1,4 @@
 from os import environ
-from typing import Optional
 
 
 def get_default_terraform_location() -> str | None:
@@ -10,10 +9,7 @@ def get_default_terraform_location() -> str | None:
     from platform import system
     from subprocess import CalledProcessError, run
 
-    if system() == "Windows":
-        cmd = ["where", "terraform"]
-    else:
-        cmd = ["which", "terraform"]
+    cmd = ["where", "terraform"] if system() == "Windows" else ["which", "terraform"]
 
     try:
         output = run(cmd, check=True, capture_output=True, encoding="utf-8")

--- a/pyterraformer/terraform/backends/base_backend.py
+++ b/pyterraformer/terraform/backends/base_backend.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import ClassVar, Dict
+from typing import ClassVar
 
 from pyterraformer.core.generics import Backend
 

--- a/pyterraformer/terraform/backends/gcs_backend.py
+++ b/pyterraformer/terraform/backends/gcs_backend.py
@@ -6,7 +6,10 @@ from pyterraformer.terraform.backends.base_backend import BaseBackend
 
 @dataclass
 class GCSBackend(BaseBackend):
-    """Stores the state as an object in a configurable prefix in a pre-existing bucket on Google Cloud Storage (GCS). The bucket must exist prior to configuring the backend."""
+    """Stores the state as an object in a configurable prefix in a pre-existing bucket on GCS.
+
+    The bucket must exist prior to configuring the backend.
+    """
 
     credentials: str | None = None
     impersonate_service_account: str | None = None

--- a/pyterraformer/terraform/backends/gcs_backend.py
+++ b/pyterraformer/terraform/backends/gcs_backend.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar
 
 from pyterraformer.terraform.backends.base_backend import BaseBackend
 

--- a/pyterraformer/terraform/backends/local_backend.py
+++ b/pyterraformer/terraform/backends/local_backend.py
@@ -1,7 +1,6 @@
 import atexit
 from dataclasses import dataclass
 from tempfile import TemporaryDirectory
-from typing import Dict, Optional
 
 from pyterraformer.core.generics import Backend
 from pyterraformer.terraform.backends.base_backend import BaseBackend

--- a/pyterraformer/terraform/terraform.py
+++ b/pyterraformer/terraform/terraform.py
@@ -52,7 +52,7 @@ class Terraform:
         cmd_array: list[str] = [self.terraform_exec_path, *arguments]
 
         def run_cmd():
-            return sub_run(
+            return sub_run(  # noqa: S603
                 cmd_array,
                 cwd=path,
                 env=runtime_env,

--- a/pyterraformer/terraform/terraform.py
+++ b/pyterraformer/terraform/terraform.py
@@ -3,7 +3,6 @@ import re
 from dataclasses import dataclass, field
 from subprocess import CalledProcessError
 from subprocess import run as sub_run
-from typing import List, Optional, Union
 
 from pyterraformer.constants import logger
 from pyterraformer.settings import get_default_terraform_location


### PR DESCRIPTION
## Summary
- Use `from __future__ import annotations` for PEP 563 deferred annotation evaluation
- Remove string quotes from type annotations (now lazily evaluated)
- Fix ruff style issues (B904, SIM101, SIM108, SIM114, SIM118) instead of ignoring them
- Simplify pyproject.toml ruff ignore list to only essential rules (E501, S101)
- Remove ~150 lines of commented-out/dead code across the codebase

## Changes
- **pyproject.toml**: Simplified ruff ignore list from 8 rules to 2
- **Type annotations**: Added `from __future__ import annotations` to enable lazy evaluation
- **Exception handling**: Added proper `raise ... from err` for exception chaining (B904)
- **Code cleanup**: Removed commented-out render methods, TODO comments, and unused imports
- **Style fixes**: Merged isinstance calls, used ternary operators, removed `.keys()` from dict iteration

## Test plan
- [x] All existing tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] Coverage threshold met (40%)

## Changelog
PH: FRL-
BR: achinchwadkar
tested: true