### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.2.0] - 2026-01-26
+
+### Changed
+- Modernized type annotations using `from __future__ import annotations` (PEP 563)
+- Removed string quotes from type annotations (now lazily evaluated)
+- Fixed ruff style issues (B904, SIM101, SIM108, SIM114, SIM118) instead of suppressing them
+- Simplified pyproject.toml ruff configuration with per-file ignores
+- Improved exception handling with proper `raise ... from err` chaining
+
+### Removed
+- ~150 lines of commented-out/dead code across the codebase
+- Unused imports and TODO comments
+- Global ruff ignore rules (moved to targeted per-file exceptions)
+
 ## [0.1.0] - 2026-01-26
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Pyterraformer - 0.1.0
+# Pyterraformer - 0.2.0
 
 [![CI pipeline status](https://github.com/wayfair-incubator/pyterraformer/workflows/CI/badge.svg?branch=main)][ci]
 [![PyPI](https://img.shields.io/pypi/v/pyterraformer)](https://pypi.org/project/pyterraformer/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyterraformer"
-version = "0.1.0"
+version = "0.2.0"
 description = "Enjoyable terraform manipulation from python."
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyterraformer/__init__.py
+++ b/pyterraformer/__init__.py
@@ -4,7 +4,7 @@ from .serializer import HumanSerializer
 from .terraform.backends import LocalBackend
 from .terraform.terraform import Terraform
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "HumanSerializer",


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0 to 0.2.0
- Update CHANGELOG.md with 0.2.0 release notes

## Changes
- **pyproject.toml**: version 0.1.0 → 0.2.0
- **pyterraformer/__init__.py**: __version__ 0.1.0 → 0.2.0
- **docs/index.md**: header version 0.1.0 → 0.2.0
- **CHANGELOG.md**: Added 0.2.0 release section

## 0.2.0 Release Highlights
- Modernized type annotations using `from __future__ import annotations` (PEP 563)
- Fixed ruff style issues instead of suppressing them
- Removed ~150 lines of dead/commented-out code
- Improved exception handling with proper chaining

## Test plan
- [x] All existing tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes

## Changelog
PH: FRL-
BR: achinchwadkar
tested: true